### PR TITLE
Add an example to create DB instance (MySQL) on AWS

### DIFF
--- a/examples/aws-db/main.tf
+++ b/examples/aws-db/main.tf
@@ -1,0 +1,62 @@
+# Define the required version of Terraform and the providers that will be used in the project
+terraform {
+  # Required OpenTofu version
+  required_version = "~>1.8.3"
+
+  required_providers {
+    # AWS provider is specified with its source and version from OpenTofu registry
+    aws = {
+      source  = "registry.opentofu.org/hashicorp/aws"
+      version = "~>5.42"
+    }
+  }
+}
+
+# Provider block for AWS specifies the configuration for the provider
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+# Create a security group for RDS Database Instance
+resource "aws_security_group" "rds_sg" {
+  name = "rds_sg"
+  
+  ingress {
+    description = "Allow MySQL traffic"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]  # Consider restricting this for security
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"  # -1 allows all protocols
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "rds_sg"
+  }
+}
+
+# Create an RDS Database Instance with updated instance class and engine version
+resource "aws_db_instance" "myinstance" {
+  engine               = "mysql"
+  identifier           = "myrdsinstance"
+  allocated_storage    = 20
+  engine_version       = "8.0.39"  # Use a compatible version of MySQL
+  instance_class       = "db.t3.micro"  # Updated to a supported instance class
+  username             = "myrdsuser"
+  password             = "myrdspassword"
+  parameter_group_name = "default.mysql8.0"
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  skip_final_snapshot  = true
+  publicly_accessible  = true
+
+  tags = {
+    Name = "myrdsinstance"
+  }
+}

--- a/examples/aws-db/output.tf
+++ b/examples/aws-db/output.tf
@@ -1,0 +1,7 @@
+#outputs.tf
+output "security_group_id" {
+  value       = aws_security_group.rds_sg.id
+}
+output "db_instance_endpoint" {
+  value       = aws_db_instance.myinstance.endpoint
+}


### PR DESCRIPTION

### Description
* Used the default VPC (when VPC is not specified)
* Created a DB instance and a security group by `tofu apply`
  - Result as follows (it took 3m54s)
  ```bash
  aws_db_instance.myinstance: Creation complete after 3m54s [id=db-MOONW7VYOB3XXXXXXXXBLFBA]
  
  Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
  
  Outputs:
  
  db_instance_endpoint = "myrdsinstance.chrxxxxxx1.ap-northeast-2.rds.amazonaws.com:3306"
  security_group_id = "sg-03abxxxxxxxa17f"
  ```
  ![image](https://github.com/user-attachments/assets/750c9476-7b85-4ffc-a8b8-19190623cc7a)

* Deleted the DB instance and the security group by `tofu destroy`
  - Result as follows (it took 4m33s)
  ```bash
  aws_db_instance.myinstance: Destruction complete after 4m33s
  aws_security_group.rds_sg: Destroying... [id=sg-03ab68xxxxxxx17f]
  aws_security_group.rds_sg: Destruction complete after 1s
  ```
  ![image](https://github.com/user-attachments/assets/cf9ff38f-fc10-4767-a03d-7aba6370db17)
  ![image](https://github.com/user-attachments/assets/cc5f36b4-8232-4bc2-9ce6-e895a3227bbd)

