### PR TITLE
Support creating DB instance in GCP

### DIFF
--- a/templates/sql-db/gcp/output.tf
+++ b/templates/sql-db/gcp/output.tf
@@ -1,0 +1,11 @@
+# Outputs wrapped in SqlDbInstanceInfo object, including public IP
+output "sql_db_info" {
+  value = {
+    instance_name   = google_sql_database_instance.instance.name
+    database_name   = google_sql_database.engine.name
+    database_user   = google_sql_user.admin_user.name
+    connection_name = google_sql_database_instance.instance.connection_name
+    public_ip       = google_sql_database_instance.instance.public_ip_address
+  }
+  description = "Information for SQL Database instance, including instance name, database name, user, connection name, and public IP address"
+}

--- a/templates/sql-db/gcp/providers.tf
+++ b/templates/sql-db/gcp/providers.tf
@@ -1,0 +1,31 @@
+# Define the required version of Terraform and the providers that will be used in the project
+terraform {
+  # Required Tofu version
+  required_version = "~>1.8.3"
+
+  required_providers {
+    # Google provider is specified with its source and version
+    google = {
+      source  = "hashicorp/google"
+      version = "~>5.21"
+    }
+  }
+}
+
+# CAUTION: Manage your credentials carefully to avoid disclosure.
+locals {
+  # Read and assign credential JSON string
+  my_gcp_credential = file("../../../secrets/credential-gcp.json")
+  # Decode JSON string and get project ID
+  my_gcp_project_id = jsondecode(local.my_gcp_credential).project_id
+}
+
+# Provider block for Google specifies the configuration for the provider
+provider "google" {
+  credentials = local.my_gcp_credential
+
+  project = local.my_gcp_project_id
+  region  = var.csp_region
+  # zone    = "asia-northeast3-c"
+}
+

--- a/templates/sql-db/gcp/sql-db.tf
+++ b/templates/sql-db/gcp/sql-db.tf
@@ -1,0 +1,25 @@
+# Create SQL MySQL instance
+resource "google_sql_database_instance" "instance" {
+  name             = "${var.terrarium_id}-db-instance"
+  database_version = var.db_engine_version # Specify the MySQL version you need, such as MYSQL_8_0
+  # region           = "us-central1"
+
+  settings {
+    tier = var.db_instance_spec # Set the instance type, such as db-f1-micro
+  }
+
+  # deletion_protection = false # Disable deletion protection
+}
+
+# Create database
+resource "google_sql_database" "engine" {
+  name     = "${var.terrarium_id}-db-engine"
+  instance = google_sql_database_instance.instance.name
+}
+
+# Create user (optional)
+resource "google_sql_user" "admin_user" {
+  instance = google_sql_database_instance.instance.name
+  name     = var.db_admin_username
+  password = var.db_admin_username # Set a strong password
+}

--- a/templates/sql-db/gcp/variables.tf
+++ b/templates/sql-db/gcp/variables.tf
@@ -1,0 +1,101 @@
+variable "terrarium_id" {
+  type        = string
+  description = "Unique ID to distinguish and manage infrastructure."
+
+  validation {
+    condition     = var.terrarium_id != ""
+    error_message = "The terrarium ID must be set"
+  }
+}
+
+
+#######################################################################
+# Google Cloud Platform (GCP)
+
+variable "csp_region" {
+  type        = string
+  description = "A location (region) in MS Azure."
+  default     = "asia-northeast3"
+
+}
+
+# variable "csp_resource_group" {
+#   type        = string
+#   default     = "tr-rg-01"
+#   description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+# }
+
+# variable "azure-virtual-network-name" {
+#   type        = string
+#   description = "A virtual network name in MS Azure."
+#   default     = "tr-azure-vnet"
+# }
+
+# # Required network information
+# variable "csp_vnet_id" {
+#   type        = string
+#   description = "The VPC ID in AWS."
+# }
+
+# variable "csp_subnet1_id" {
+#   type        = string
+#   description = "The subnet ID in Azure."
+# }
+
+# variable "csp_subnet2_id" {
+#   type        = string
+#   description = "The subnet ID in AWS."
+# }
+
+# # Required security group information
+# variable "db_engine_port" {
+#   type        = number
+#   description = "The port number for the database engine."
+#   default     = 3306
+# }
+
+# variable "ingress_cidr_block" {
+#   type        = string
+#   description = "The CIDR block for ingress traffic."
+#   default     = "0.0.0.0/0"
+# }
+
+# variable "egress_cidr_block" {
+#   type        = string
+#   description = "The CIDR block for egress traffic."
+#   default     = "0.0.0.0/0"
+# }
+
+# # Required database engine information
+# variable "db_instance_identifier" {
+#   type        = string
+#   description = "The identifier for the database."
+#   default     = "mydbinstance"
+# }
+
+variable "db_engine_version" {
+  type        = string
+  description = "The version of the database engine."
+  default     = "MYSQL_8_0"
+}
+
+variable "db_instance_spec" {
+  type        = string
+  description = "The instance class for the database."
+  default     = "db-f1-micro"
+}
+
+variable "db_admin_username" {
+  type        = string
+  description = "The admin username for the database."
+  default     = "mydbadmin"
+}
+
+# NOTE - "administrator_password" must contain characters from three of the categories 
+# – uppercase letters, lowercase letters, numbers and non-alphanumeric characters, got mysdbpass
+variable "db_admin_password" {
+  type        = string
+  description = "The admin password for the database."
+  default     = "P@ssword1234!"
+}
+


### PR DESCRIPTION
The test sequence and results are almost similar to https://github.com/cloud-barista/mc-terrarium/pull/103.

The request body was updated and different from "2. Create an infracode for the SQL database"

* Request body:
  ```json
  {
    "tfVars": {
      "csp_region": "asia-northeast3",
      "db_admin_password": "P@ssword1234!",
      "db_admin_username": "mydbadmin",
      "db_engine_version": "MYSQL_8_0",
      "db_instance_spec": "db-f1-micro",
      "terrarium_id": ""
    }
  }
  ```