### PR TITLE
Add AWS MQ (ActiveMQ) example

### DIFF
--- a/examples/aws/mq-broker/main.tf
+++ b/examples/aws/mq-broker/main.tf
@@ -1,0 +1,87 @@
+# Define the required version of Terraform and the providers that will be used in the project
+terraform {
+  # Required Tofu version
+  required_version = "~>1.8.3"
+
+  required_providers {
+    # AWS provider is specified with its source and version
+    aws = {
+      source  = "registry.opentofu.org/hashicorp/aws"
+      version = "~>5.42"
+    }
+  }
+}
+
+# Provider block for AWS specifies the configuration for the provider
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+
+# Define the VPC resource block
+resource "aws_vpc" "tofu_example" {
+  cidr_block = "192.168.64.0/22"
+
+  tags = {
+    Name = "tofu-101"
+  }
+}
+
+# Amazon MQ Broker (ActiveMQ)
+resource "aws_mq_broker" "tofu_example" {
+  broker_name    = "tofu-broker"
+  engine_type    = "ActiveMQ" # RabbitMQ is also available
+  engine_version = "5.17.6"   # Valid values: [5.18, 5.17.6, 5.16.7]
+  # auto_minor_version_upgrade = true       # Brokers on [ActiveMQ] version [5.18] must have [autoMinorVersionUpgrade] set to [true]
+  host_instance_type  = "mq.t3.micro"
+  publicly_accessible = true
+
+  user {
+    username = "admin"
+    password = "examplepassword"
+  }
+}
+
+# Security Group for Amazon MQ
+resource "aws_security_group" "mq_sg" {
+  name_prefix = "tofu-mq-sg-"
+  description = "MQ Broker Security Group"
+  vpc_id      = aws_vpc.tofu_example.id
+
+  ingress {
+    from_port   = 5671
+    to_port     = 5671
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Output Broker Information
+output "amazon_mq_broker_info" {
+  value = {
+    broker_id       = aws_mq_broker.tofu_example.id
+    broker_endpoint = aws_mq_broker.tofu_example.instances[0].endpoints[0]
+    security_group  = aws_security_group.mq_sg.id
+  }
+}
+
+output "all_vpc_info" {
+  value = aws_vpc.tofu_example
+}
+
+
+output "all_security_group_info" {
+  value = aws_security_group.mq_sg
+}
+
+output "all_mq_broker_info" {
+  value     = aws_mq_broker.tofu_example
+  sensitive = true
+}

--- a/templates/vpn/gcp-aws/output.tf
+++ b/templates/vpn/gcp-aws/output.tf
@@ -96,38 +96,38 @@ output "vpn_info" {
     aws = {
       vpn_gateway = {
         resource_type = "aws_vpn_gateway"
-        name         = aws_vpn_gateway.vpn_gw.tags.Name
-        id           = aws_vpn_gateway.vpn_gw.id
-        vpc_id       = aws_vpn_gateway.vpn_gw.vpc_id
+        name          = aws_vpn_gateway.vpn_gw.tags.Name
+        id            = aws_vpn_gateway.vpn_gw.id
+        vpc_id        = aws_vpn_gateway.vpn_gw.vpc_id
       }
       customer_gateways = [
         {
           resource_type = "aws_customer_gateway"
-          name         = aws_customer_gateway.cgw_1.tags.Name
-          id           = aws_customer_gateway.cgw_1.id
-          ip_address   = aws_customer_gateway.cgw_1.ip_address
-          bgp_asn      = aws_customer_gateway.cgw_1.bgp_asn
+          name          = aws_customer_gateway.cgw_1.tags.Name
+          id            = aws_customer_gateway.cgw_1.id
+          ip_address    = aws_customer_gateway.cgw_1.ip_address
+          bgp_asn       = aws_customer_gateway.cgw_1.bgp_asn
         },
         {
           resource_type = "aws_customer_gateway"
-          name         = aws_customer_gateway.cgw_2.tags.Name
-          id           = aws_customer_gateway.cgw_2.id
-          ip_address   = aws_customer_gateway.cgw_2.ip_address
-          bgp_asn      = aws_customer_gateway.cgw_2.bgp_asn
+          name          = aws_customer_gateway.cgw_2.tags.Name
+          id            = aws_customer_gateway.cgw_2.id
+          ip_address    = aws_customer_gateway.cgw_2.ip_address
+          bgp_asn       = aws_customer_gateway.cgw_2.bgp_asn
         }
       ]
       vpn_connections = [
         {
-          resource_type = "aws_vpn_connection"
-          name         = aws_vpn_connection.vpn_cnx_1.tags.Name
-          id           = aws_vpn_connection.vpn_cnx_1.id
+          resource_type   = "aws_vpn_connection"
+          name            = aws_vpn_connection.vpn_cnx_1.tags.Name
+          id              = aws_vpn_connection.vpn_cnx_1.id
           tunnel1_address = aws_vpn_connection.vpn_cnx_1.tunnel1_address
           tunnel2_address = aws_vpn_connection.vpn_cnx_1.tunnel2_address
         },
         {
-          resource_type = "aws_vpn_connection"
-          name         = aws_vpn_connection.vpn_cnx_2.tags.Name
-          id           = aws_vpn_connection.vpn_cnx_2.id
+          resource_type   = "aws_vpn_connection"
+          name            = aws_vpn_connection.vpn_cnx_2.tags.Name
+          id              = aws_vpn_connection.vpn_cnx_2.id
           tunnel1_address = aws_vpn_connection.vpn_cnx_2.tunnel1_address
           tunnel2_address = aws_vpn_connection.vpn_cnx_2.tunnel2_address
         }
@@ -136,46 +136,46 @@ output "vpn_info" {
     gcp = {
       router = {
         resource_type = "google_compute_router"
-        name         = google_compute_router.router_1.name
-        id           = google_compute_router.router_1.id
-        network      = google_compute_router.router_1.network
-        bgp_asn      = google_compute_router.router_1.bgp[0].asn
+        name          = google_compute_router.router_1.name
+        id            = google_compute_router.router_1.id
+        network       = google_compute_router.router_1.network
+        bgp_asn       = google_compute_router.router_1.bgp[0].asn
       }
       ha_vpn_gateway = {
         resource_type = "google_compute_ha_vpn_gateway"
-        name         = google_compute_ha_vpn_gateway.ha_vpn_gw_1.name
-        id           = google_compute_ha_vpn_gateway.ha_vpn_gw_1.id
-        network      = google_compute_ha_vpn_gateway.ha_vpn_gw_1.network
-        ip_addresses = google_compute_ha_vpn_gateway.ha_vpn_gw_1.vpn_interfaces[*].ip_address
+        name          = google_compute_ha_vpn_gateway.ha_vpn_gw_1.name
+        id            = google_compute_ha_vpn_gateway.ha_vpn_gw_1.id
+        network       = google_compute_ha_vpn_gateway.ha_vpn_gw_1.network
+        ip_addresses  = google_compute_ha_vpn_gateway.ha_vpn_gw_1.vpn_interfaces[*].ip_address
       }
       vpn_tunnels = [
         {
           resource_type = "google_compute_vpn_tunnel"
-          name         = google_compute_vpn_tunnel.vpn_tunnel_1.name
-          id           = google_compute_vpn_tunnel.vpn_tunnel_1.id
-          ike_version  = google_compute_vpn_tunnel.vpn_tunnel_1.ike_version
-          interface    = google_compute_vpn_tunnel.vpn_tunnel_1.vpn_gateway_interface
+          name          = google_compute_vpn_tunnel.vpn_tunnel_1.name
+          id            = google_compute_vpn_tunnel.vpn_tunnel_1.id
+          ike_version   = google_compute_vpn_tunnel.vpn_tunnel_1.ike_version
+          interface     = google_compute_vpn_tunnel.vpn_tunnel_1.vpn_gateway_interface
         },
         {
           resource_type = "google_compute_vpn_tunnel"
-          name         = google_compute_vpn_tunnel.vpn_tunnel_2.name
-          id           = google_compute_vpn_tunnel.vpn_tunnel_2.id
-          ike_version  = google_compute_vpn_tunnel.vpn_tunnel_2.ike_version
-          interface    = google_compute_vpn_tunnel.vpn_tunnel_2.vpn_gateway_interface
+          name          = google_compute_vpn_tunnel.vpn_tunnel_2.name
+          id            = google_compute_vpn_tunnel.vpn_tunnel_2.id
+          ike_version   = google_compute_vpn_tunnel.vpn_tunnel_2.ike_version
+          interface     = google_compute_vpn_tunnel.vpn_tunnel_2.vpn_gateway_interface
         },
         {
           resource_type = "google_compute_vpn_tunnel"
-          name         = google_compute_vpn_tunnel.vpn_tunnel_3.name
-          id           = google_compute_vpn_tunnel.vpn_tunnel_3.id
-          ike_version  = google_compute_vpn_tunnel.vpn_tunnel_3.ike_version
-          interface    = google_compute_vpn_tunnel.vpn_tunnel_3.vpn_gateway_interface
+          name          = google_compute_vpn_tunnel.vpn_tunnel_3.name
+          id            = google_compute_vpn_tunnel.vpn_tunnel_3.id
+          ike_version   = google_compute_vpn_tunnel.vpn_tunnel_3.ike_version
+          interface     = google_compute_vpn_tunnel.vpn_tunnel_3.vpn_gateway_interface
         },
         {
           resource_type = "google_compute_vpn_tunnel"
-          name         = google_compute_vpn_tunnel.vpn_tunnel_4.name
-          id           = google_compute_vpn_tunnel.vpn_tunnel_4.id
-          ike_version  = google_compute_vpn_tunnel.vpn_tunnel_4.ike_version
-          interface    = google_compute_vpn_tunnel.vpn_tunnel_4.vpn_gateway_interface
+          name          = google_compute_vpn_tunnel.vpn_tunnel_4.name
+          id            = google_compute_vpn_tunnel.vpn_tunnel_4.id
+          ike_version   = google_compute_vpn_tunnel.vpn_tunnel_4.ike_version
+          interface     = google_compute_vpn_tunnel.vpn_tunnel_4.vpn_gateway_interface
         }
       ]
     }


### PR DESCRIPTION
This PR will add an example of AWS MQ (ActiveMQ).

This is a customized output block.
```hcl
amazon_mq_broker_info = {
  "broker_endpoint" = "ssl://[BROKER_ID].mq.ap-northeast-2.amazonaws.com:61617"
  "broker_id" = "[BROKER_ID]"
  "security_group" = "sg-0xxxxxxxxxxxxxxxxx"
}
```

This is all the information of aws_mq_broker created.
```hcl
# aws_mq_broker.tofu_example:
resource "aws_mq_broker" "tofu_example" {
    apply_immediately          = false
    arn                        = "arn:aws:mq:ap-northeast-2:000000000000:broker:tofu-broker:[BROKER_ID]"
    authentication_strategy    = "simple"
    auto_minor_version_upgrade = false
    broker_name                = "tofu-broker"
    deployment_mode            = "SINGLE_INSTANCE"
    engine_type                = "ActiveMQ"
    engine_version             = "5.17.6"
    host_instance_type         = "mq.t3.micro"
    id                         = "[BROKER_ID]"
    instances                  = [
        {
            console_url = "https://[BROKER_ID]-1.mq.ap-northeast-2.amazonaws.com:8162"
            endpoints   = [
                "ssl://[BROKER_ID]-1.mq.ap-northeast-2.amazonaws.com:61617",
                "amqp+ssl://[BROKER_ID]-1.mq.ap-northeast-2.amazonaws.com:5671",
                "stomp+ssl://[BROKER_ID]4-1.mq.ap-northeast-2.amazonaws.com:61614",
                "mqtt+ssl://[BROKER_ID]-1.mq.ap-northeast-2.amazonaws.com:8883",
                "wss://[BROKER_ID]-1.mq.ap-northeast-2.amazonaws.com:61619",
            ]
            ip_address  = "x.x.xxx.xx.xx"
        },
    ]
    publicly_accessible        = true
    security_groups            = [
        "sg-c689xxxxxe",
    ]
    storage_type               = "efs"
    subnet_ids                 = [
        "subnet-daxxxxxb97",
    ]
    tags_all                   = {}

    configuration {
        id       = "c-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
        revision = 1
    }

    encryption_options {
        use_aws_owned_key = true
    }

    logs {
        audit   = "false"
        general = false
    }

    maintenance_window_start_time {
        day_of_week = "MONDAY"
        time_of_day = "21:00"
        time_zone   = "UTC"
    }

    user {
      # At least one attribute in this block is (or was) sensitive,
      # so its contents will not be displayed.
    }
}


```
