### PR TITLE
Provide APIs of AWS-to-site VPN

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2055,6 +2055,555 @@ const docTemplate = `{
                 }
             }
         },
+        "/tr/{trId}/vpn/aws-to-site": {
+            "get": {
+                "description": "Get AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] Resource Operations"
+                ],
+                "summary": "Get AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "refined",
+                            "raw"
+                        ],
+                        "type": "string",
+                        "default": "refined",
+                        "description": "Resource info by detail (refined, raw)",
+                        "name": "detail",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] Resource Operations"
+                ],
+                "summary": "Create AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Parameters requied to create the AWS to site VPN",
+                        "name": "ReqBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateAwsToSiteVpnRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] Resource Operations"
+                ],
+                "summary": "Delete AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/apply": {
+            "post": {
+                "description": "Apply AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Apply AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/destroy": {
+            "delete": {
+                "description": "Destroy AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Destroy AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/emptyout": {
+            "delete": {
+                "description": "EmptyOut AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "EmptyOut AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/init": {
+            "post": {
+                "description": "Init AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Init AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Parameters requied to create the AWS to site VPN",
+                        "name": "ReqBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateAwsToSiteVpnRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/output": {
+            "get": {
+                "description": "Output AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Output AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "refined",
+                            "raw"
+                        ],
+                        "type": "string",
+                        "default": "refined",
+                        "description": "Resource info by detail (refined, raw)",
+                        "name": "detail",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/plan": {
+            "post": {
+                "description": "Plan AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Plan AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/tr/{trId}/vpn/gcp-aws": {
             "get": {
                 "description": "Get resource info to configure GCP to AWS VPN tunnels",
@@ -2991,6 +3540,95 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "model.AlibabaConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65532",
+                    "example": "65532"
+                },
+                "region": {
+                    "type": "string",
+                    "default": "ap-northeast-2",
+                    "example": "ap-northeast-2"
+                },
+                "vpc_id": {
+                    "type": "string"
+                },
+                "vswitch_id_1": {
+                    "type": "string"
+                },
+                "vswitch_id_2": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AwsConfig": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "string",
+                    "default": "ap-northeast-2",
+                    "example": "ap-northeast-2"
+                },
+                "subnet_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AwsToSiteVpnConfig": {
+            "type": "object",
+            "properties": {
+                "aws": {
+                    "$ref": "#/definitions/model.AwsConfig"
+                },
+                "target_csp": {
+                    "$ref": "#/definitions/model.TargetCspConfig"
+                },
+                "terrarium_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AzureConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65531",
+                    "example": "65531"
+                },
+                "gateway_subnet_cidr": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "resource_group_name": {
+                    "type": "string"
+                },
+                "virtual_network_name": {
+                    "type": "string"
+                },
+                "vpn_sku": {
+                    "type": "string",
+                    "default": "VpnGw1AZ",
+                    "example": "VpnGw1AZ"
+                }
+            }
+        },
+        "model.CreateAwsToSiteVpnRequest": {
+            "type": "object",
+            "properties": {
+                "vpn_config": {
+                    "$ref": "#/definitions/model.AwsToSiteVpnConfig"
+                }
+            }
+        },
         "model.CreateInfracodeOfGcpAwsVpnRequest": {
             "type": "object",
             "properties": {
@@ -3039,6 +3677,48 @@ const docTemplate = `{
                 }
             }
         },
+        "model.GcpConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65530",
+                    "example": "65530"
+                },
+                "region": {
+                    "type": "string",
+                    "default": "asia-northeast3",
+                    "example": "asia-northeast3"
+                },
+                "vpc_network_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.IbmConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65533",
+                    "example": "65533"
+                },
+                "region": {
+                    "type": "string",
+                    "default": "au-syd",
+                    "example": "au-syd"
+                },
+                "subnet_id": {
+                    "type": "string"
+                },
+                "vpc_cidr": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
         "model.Response": {
             "type": "object",
             "properties": {
@@ -3065,6 +3745,26 @@ const docTemplate = `{
                 "success": {
                     "type": "boolean",
                     "example": true
+                }
+            }
+        },
+        "model.TargetCspConfig": {
+            "type": "object",
+            "properties": {
+                "alibaba": {
+                    "$ref": "#/definitions/model.AlibabaConfig"
+                },
+                "azure": {
+                    "$ref": "#/definitions/model.AzureConfig"
+                },
+                "gcp": {
+                    "$ref": "#/definitions/model.GcpConfig"
+                },
+                "ibm": {
+                    "$ref": "#/definitions/model.IbmConfig"
+                },
+                "type": {
+                    "type": "string"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2049,6 +2049,555 @@
                 }
             }
         },
+        "/tr/{trId}/vpn/aws-to-site": {
+            "get": {
+                "description": "Get AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] Resource Operations"
+                ],
+                "summary": "Get AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "refined",
+                            "raw"
+                        ],
+                        "type": "string",
+                        "default": "refined",
+                        "description": "Resource info by detail (refined, raw)",
+                        "name": "detail",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] Resource Operations"
+                ],
+                "summary": "Create AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Parameters requied to create the AWS to site VPN",
+                        "name": "ReqBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateAwsToSiteVpnRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] Resource Operations"
+                ],
+                "summary": "Delete AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/apply": {
+            "post": {
+                "description": "Apply AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Apply AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/destroy": {
+            "delete": {
+                "description": "Destroy AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Destroy AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/emptyout": {
+            "delete": {
+                "description": "EmptyOut AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "EmptyOut AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/init": {
+            "post": {
+                "description": "Init AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Init AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Parameters requied to create the AWS to site VPN",
+                        "name": "ReqBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.CreateAwsToSiteVpnRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/output": {
+            "get": {
+                "description": "Output AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Output AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "refined",
+                            "raw"
+                        ],
+                        "type": "string",
+                        "default": "refined",
+                        "description": "Resource info by detail (refined, raw)",
+                        "name": "detail",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/tr/{trId}/vpn/aws-to-site/actions/plan": {
+            "post": {
+                "description": "Plan AWS to site VPN",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)"
+                ],
+                "summary": "Plan AWS to site VPN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "tr01",
+                        "description": "Terrarium ID",
+                        "name": "trId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/tr/{trId}/vpn/gcp-aws": {
             "get": {
                 "description": "Get resource info to configure GCP to AWS VPN tunnels",
@@ -2985,6 +3534,95 @@
         }
     },
     "definitions": {
+        "model.AlibabaConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65532",
+                    "example": "65532"
+                },
+                "region": {
+                    "type": "string",
+                    "default": "ap-northeast-2",
+                    "example": "ap-northeast-2"
+                },
+                "vpc_id": {
+                    "type": "string"
+                },
+                "vswitch_id_1": {
+                    "type": "string"
+                },
+                "vswitch_id_2": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AwsConfig": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "string",
+                    "default": "ap-northeast-2",
+                    "example": "ap-northeast-2"
+                },
+                "subnet_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AwsToSiteVpnConfig": {
+            "type": "object",
+            "properties": {
+                "aws": {
+                    "$ref": "#/definitions/model.AwsConfig"
+                },
+                "target_csp": {
+                    "$ref": "#/definitions/model.TargetCspConfig"
+                },
+                "terrarium_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.AzureConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65531",
+                    "example": "65531"
+                },
+                "gateway_subnet_cidr": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "resource_group_name": {
+                    "type": "string"
+                },
+                "virtual_network_name": {
+                    "type": "string"
+                },
+                "vpn_sku": {
+                    "type": "string",
+                    "default": "VpnGw1AZ",
+                    "example": "VpnGw1AZ"
+                }
+            }
+        },
+        "model.CreateAwsToSiteVpnRequest": {
+            "type": "object",
+            "properties": {
+                "vpn_config": {
+                    "$ref": "#/definitions/model.AwsToSiteVpnConfig"
+                }
+            }
+        },
         "model.CreateInfracodeOfGcpAwsVpnRequest": {
             "type": "object",
             "properties": {
@@ -3033,6 +3671,48 @@
                 }
             }
         },
+        "model.GcpConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65530",
+                    "example": "65530"
+                },
+                "region": {
+                    "type": "string",
+                    "default": "asia-northeast3",
+                    "example": "asia-northeast3"
+                },
+                "vpc_network_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.IbmConfig": {
+            "type": "object",
+            "properties": {
+                "bgp_asn": {
+                    "type": "string",
+                    "default": "65533",
+                    "example": "65533"
+                },
+                "region": {
+                    "type": "string",
+                    "default": "au-syd",
+                    "example": "au-syd"
+                },
+                "subnet_id": {
+                    "type": "string"
+                },
+                "vpc_cidr": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
         "model.Response": {
             "type": "object",
             "properties": {
@@ -3059,6 +3739,26 @@
                 "success": {
                     "type": "boolean",
                     "example": true
+                }
+            }
+        },
+        "model.TargetCspConfig": {
+            "type": "object",
+            "properties": {
+                "alibaba": {
+                    "$ref": "#/definitions/model.AlibabaConfig"
+                },
+                "azure": {
+                    "$ref": "#/definitions/model.AzureConfig"
+                },
+                "gcp": {
+                    "$ref": "#/definitions/model.GcpConfig"
+                },
+                "ibm": {
+                    "$ref": "#/definitions/model.IbmConfig"
+                },
+                "type": {
+                    "type": "string"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,5 +1,66 @@
 basePath: /terrarium
 definitions:
+  model.AlibabaConfig:
+    properties:
+      bgp_asn:
+        default: "65532"
+        example: "65532"
+        type: string
+      region:
+        default: ap-northeast-2
+        example: ap-northeast-2
+        type: string
+      vpc_id:
+        type: string
+      vswitch_id_1:
+        type: string
+      vswitch_id_2:
+        type: string
+    type: object
+  model.AwsConfig:
+    properties:
+      region:
+        default: ap-northeast-2
+        example: ap-northeast-2
+        type: string
+      subnet_id:
+        type: string
+      vpc_id:
+        type: string
+    type: object
+  model.AwsToSiteVpnConfig:
+    properties:
+      aws:
+        $ref: '#/definitions/model.AwsConfig'
+      target_csp:
+        $ref: '#/definitions/model.TargetCspConfig'
+      terrarium_id:
+        type: string
+    type: object
+  model.AzureConfig:
+    properties:
+      bgp_asn:
+        default: "65531"
+        example: "65531"
+        type: string
+      gateway_subnet_cidr:
+        type: string
+      region:
+        type: string
+      resource_group_name:
+        type: string
+      virtual_network_name:
+        type: string
+      vpn_sku:
+        default: VpnGw1AZ
+        example: VpnGw1AZ
+        type: string
+    type: object
+  model.CreateAwsToSiteVpnRequest:
+    properties:
+      vpn_config:
+        $ref: '#/definitions/model.AwsToSiteVpnConfig'
+    type: object
   model.CreateInfracodeOfGcpAwsVpnRequest:
     properties:
       tfVars:
@@ -30,6 +91,36 @@ definitions:
       tfVars:
         $ref: '#/definitions/model.TfVarsTestEnv'
     type: object
+  model.GcpConfig:
+    properties:
+      bgp_asn:
+        default: "65530"
+        example: "65530"
+        type: string
+      region:
+        default: asia-northeast3
+        example: asia-northeast3
+        type: string
+      vpc_network_name:
+        type: string
+    type: object
+  model.IbmConfig:
+    properties:
+      bgp_asn:
+        default: "65533"
+        example: "65533"
+        type: string
+      region:
+        default: au-syd
+        example: au-syd
+        type: string
+      subnet_id:
+        type: string
+      vpc_cidr:
+        type: string
+      vpc_id:
+        type: string
+    type: object
   model.Response:
     properties:
       details:
@@ -50,6 +141,19 @@ definitions:
       success:
         example: true
         type: boolean
+    type: object
+  model.TargetCspConfig:
+    properties:
+      alibaba:
+        $ref: '#/definitions/model.AlibabaConfig'
+      azure:
+        $ref: '#/definitions/model.AzureConfig'
+      gcp:
+        $ref: '#/definitions/model.GcpConfig'
+      ibm:
+        $ref: '#/definitions/model.IbmConfig'
+      type:
+        type: string
     type: object
   model.TerrariumInfo:
     properties:
@@ -1574,6 +1678,374 @@ paths:
       summary: Check the status of a specific request by its ID
       tags:
       - '[SQL Database] Operations'
+  /tr/{trId}/vpn/aws-to-site:
+    delete:
+      consumes:
+      - application/json
+      description: Delete AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Delete AWS to site VPN
+      tags:
+      - '[AWS to site VPN] Resource Operations'
+    get:
+      consumes:
+      - application/json
+      description: Get AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - default: refined
+        description: Resource info by detail (refined, raw)
+        enum:
+        - refined
+        - raw
+        in: query
+        name: detail
+        type: string
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Get AWS to site VPN
+      tags:
+      - '[AWS to site VPN] Resource Operations'
+    post:
+      consumes:
+      - application/json
+      description: Create AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - description: Parameters requied to create the AWS to site VPN
+        in: body
+        name: ReqBody
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateAwsToSiteVpnRequest'
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Create AWS to site VPN
+      tags:
+      - '[AWS to site VPN] Resource Operations'
+  /tr/{trId}/vpn/aws-to-site/actions/apply:
+    post:
+      consumes:
+      - application/json
+      description: Apply AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Apply AWS to site VPN
+      tags:
+      - '[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)'
+  /tr/{trId}/vpn/aws-to-site/actions/destroy:
+    delete:
+      consumes:
+      - application/json
+      description: Destroy AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Destroy AWS to site VPN
+      tags:
+      - '[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)'
+  /tr/{trId}/vpn/aws-to-site/actions/emptyout:
+    delete:
+      consumes:
+      - application/json
+      description: EmptyOut AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: EmptyOut AWS to site VPN
+      tags:
+      - '[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)'
+  /tr/{trId}/vpn/aws-to-site/actions/init:
+    post:
+      consumes:
+      - application/json
+      description: Init AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - description: Parameters requied to create the AWS to site VPN
+        in: body
+        name: ReqBody
+        required: true
+        schema:
+          $ref: '#/definitions/model.CreateAwsToSiteVpnRequest'
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Init AWS to site VPN
+      tags:
+      - '[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)'
+  /tr/{trId}/vpn/aws-to-site/actions/output:
+    get:
+      consumes:
+      - application/json
+      description: Output AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - default: refined
+        description: Resource info by detail (refined, raw)
+        enum:
+        - refined
+        - raw
+        in: query
+        name: detail
+        type: string
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Output AWS to site VPN
+      tags:
+      - '[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)'
+  /tr/{trId}/vpn/aws-to-site/actions/plan:
+    post:
+      consumes:
+      - application/json
+      description: Plan AWS to site VPN
+      parameters:
+      - default: tr01
+        description: Terrarium ID
+        in: path
+        name: trId
+        required: true
+        type: string
+      - description: Custom request ID
+        in: header
+        name: x-request-id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Plan AWS to site VPN
+      tags:
+      - '[AWS to site VPN] OpenTofu Actions (for fine-grained contorl)'
   /tr/{trId}/vpn/gcp-aws:
     delete:
       consumes:

--- a/pkg/api/rest/handler/message-broker.go
+++ b/pkg/api/rest/handler/message-broker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloud-barista/mc-terrarium/pkg/api/rest/model"
 	"github.com/cloud-barista/mc-terrarium/pkg/config"
 	"github.com/cloud-barista/mc-terrarium/pkg/terrarium"
+	"github.com/cloud-barista/mc-terrarium/pkg/tofu"
 	tfutil "github.com/cloud-barista/mc-terrarium/pkg/tofu/util"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -102,7 +103,7 @@ func InitEnvForMessageBroker(c echo.Context) error {
 	enrichments := "message-broker"
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -111,7 +112,7 @@ func InitEnvForMessageBroker(c echo.Context) error {
 	}
 
 	trInfo.Enrichments = enrichments
-	err = terrarium.UpdateTerrariumInfo(trInfo)
+	err = terrarium.UpdateInfo(trInfo)
 	if err != nil {
 		err2 := fmt.Errorf("failed to update terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -164,7 +165,7 @@ func InitEnvForMessageBroker(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/message-broker
 	// init: subcommand
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "init")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "init")
 	if err != nil {
 		err2 := fmt.Errorf("failed to initialize an infrastructure terrarium")
 		log.Error().Err(err).Msg(err2.Error())
@@ -215,7 +216,7 @@ func ClearEnvOfMessageBroker(c echo.Context) error {
 	projectRoot := config.Terrarium.Root
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -298,7 +299,7 @@ func CreateInfracodeForMessageBroker(c echo.Context) error {
 	projectRoot := config.Terrarium.Root
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -331,7 +332,7 @@ func CreateInfracodeForMessageBroker(c echo.Context) error {
 		req.TfVars.TerrariumID = trId
 	}
 
-	err = tfutil.SaveTfVarsToFile(req.TfVars, tfVarsPath)
+	err = tfutil.SaveTfVars(req.TfVars, tfVarsPath)
 	if err != nil {
 		err2 := fmt.Errorf("failed to save tfVars to a file")
 		log.Error().Err(err).Msg(err2.Error())
@@ -383,7 +384,7 @@ func CheckInfracodeForMessageBroker(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -405,7 +406,7 @@ func CheckInfracodeForMessageBroker(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/message-broker
 	// subcommand: plan
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "plan")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "plan")
 	if err != nil {
 		err2 := fmt.Errorf("returned: %s", ret)
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -458,7 +459,7 @@ func CreateMessageBroker(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -480,7 +481,7 @@ func CreateMessageBroker(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/message-broker
 	// subcommand: apply
-	_, err = tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "apply", "-auto-approve")
+	_, err = tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "apply", "-auto-approve")
 	if err != nil {
 		err2 := fmt.Errorf("failed, previous request in progress")
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -493,7 +494,7 @@ func CreateMessageBroker(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/message-broker
 	// show: subcommand
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "message_broker_info")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "message_broker_info")
 	if err != nil {
 		err2 := fmt.Errorf("failed to read resource info (detail: %s) specified as 'output' in the state file", "refined")
 		log.Error().Err(err).Msg(err2.Error())
@@ -581,7 +582,7 @@ func GetResourceInfoOfMessageBroker(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -608,7 +609,7 @@ func GetResourceInfoOfMessageBroker(c echo.Context) error {
 
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/message-broker
 		// show: subcommand
-		ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "message_broker_info")
+		ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "message_broker_info")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) specified as 'output' in the state file", DetailOptions.Refined)
 			log.Error().Err(err).Msg(err2.Error())
@@ -645,7 +646,7 @@ func GetResourceInfoOfMessageBroker(c echo.Context) error {
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/message-broker
 		// show: subcommand
 		// Get resource info from the state or plan file
-		ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "show", "-json")
+		ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "show", "-json")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) from the state or plan file", DetailOptions.Raw)
 			log.Error().Err(err).Msg(err2.Error()) // error
@@ -730,7 +731,7 @@ func DestroyMessageBroker(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -753,7 +754,7 @@ func DestroyMessageBroker(c echo.Context) error {
 	// Destroy the infrastructure
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}
 	// subcommand: destroy
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
 	if err != nil {
 		err2 := fmt.Errorf("failed, previous request in progress")
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -813,7 +814,7 @@ func GetRequestStatusOfMessageBroker(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -834,7 +835,7 @@ func GetRequestStatusOfMessageBroker(c echo.Context) error {
 	statusLogFile := fmt.Sprintf("%s/runningLogs/%s.log", workingDir, reqId)
 
 	// Check the statusReport of the request
-	statusReport, err := tfutil.GetRunningStatus(trId, statusLogFile)
+	statusReport, err := tofu.GetExcutionHistory(trId, statusLogFile)
 	if err != nil {
 		err2 := fmt.Errorf("failed to get the status of the request")
 		log.Error().Err(err).Msg(err2.Error()) // error

--- a/pkg/api/rest/handler/object-storage.go
+++ b/pkg/api/rest/handler/object-storage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloud-barista/mc-terrarium/pkg/api/rest/model"
 	"github.com/cloud-barista/mc-terrarium/pkg/config"
 	"github.com/cloud-barista/mc-terrarium/pkg/terrarium"
+	"github.com/cloud-barista/mc-terrarium/pkg/tofu"
 	tfutil "github.com/cloud-barista/mc-terrarium/pkg/tofu/util"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -102,7 +103,7 @@ func InitEnvForObjectStorage(c echo.Context) error {
 	enrichments := "object-storage"
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -111,7 +112,7 @@ func InitEnvForObjectStorage(c echo.Context) error {
 	}
 
 	trInfo.Enrichments = enrichments
-	err = terrarium.UpdateTerrariumInfo(trInfo)
+	err = terrarium.UpdateInfo(trInfo)
 	if err != nil {
 		err2 := fmt.Errorf("failed to update terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -164,7 +165,7 @@ func InitEnvForObjectStorage(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/object-storage
 	// init: subcommand
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "init")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "init")
 	if err != nil {
 		err2 := fmt.Errorf("failed to initialize an infrastructure terrarium")
 		log.Error().Err(err).Msg(err2.Error())
@@ -215,7 +216,7 @@ func ClearEnvOfObjectStorage(c echo.Context) error {
 	projectRoot := config.Terrarium.Root
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -298,7 +299,7 @@ func CreateInfracodeForObjectStorage(c echo.Context) error {
 	projectRoot := config.Terrarium.Root
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -331,7 +332,7 @@ func CreateInfracodeForObjectStorage(c echo.Context) error {
 		req.TfVars.TerrariumID = trId
 	}
 
-	err = tfutil.SaveTfVarsToFile(req.TfVars, tfVarsPath)
+	err = tfutil.SaveTfVars(req.TfVars, tfVarsPath)
 	if err != nil {
 		err2 := fmt.Errorf("failed to save tfVars to a file")
 		log.Error().Err(err).Msg(err2.Error())
@@ -383,7 +384,7 @@ func CheckInfracodeForObjectStorage(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -405,7 +406,7 @@ func CheckInfracodeForObjectStorage(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/object-storage
 	// subcommand: plan
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "plan")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "plan")
 	if err != nil {
 		err2 := fmt.Errorf("returned: %s", ret)
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -458,7 +459,7 @@ func CreateObjectStorage(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -480,7 +481,7 @@ func CreateObjectStorage(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/object-storage
 	// subcommand: apply
-	_, err = tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "apply", "-auto-approve")
+	_, err = tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "apply", "-auto-approve")
 	if err != nil {
 		err2 := fmt.Errorf("failed, previous request in progress")
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -493,7 +494,7 @@ func CreateObjectStorage(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/object-storage
 	// show: subcommand
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "object_storage_info")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "object_storage_info")
 	if err != nil {
 		err2 := fmt.Errorf("failed to read resource info (detail: %s) specified as 'output' in the state file", "refined")
 		log.Error().Err(err).Msg(err2.Error())
@@ -581,7 +582,7 @@ func GetResourceInfoOfObjectStorage(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -608,7 +609,7 @@ func GetResourceInfoOfObjectStorage(c echo.Context) error {
 
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/object-storage
 		// show: subcommand
-		ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "object_storage_info")
+		ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "object_storage_info")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) specified as 'output' in the state file", DetailOptions.Refined)
 			log.Error().Err(err).Msg(err2.Error())
@@ -645,7 +646,7 @@ func GetResourceInfoOfObjectStorage(c echo.Context) error {
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/object-storage
 		// show: subcommand
 		// Get resource info from the state or plan file
-		ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "show", "-json")
+		ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "show", "-json")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) from the state or plan file", DetailOptions.Raw)
 			log.Error().Err(err).Msg(err2.Error()) // error
@@ -730,7 +731,7 @@ func DestroyObjectStorage(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -753,7 +754,7 @@ func DestroyObjectStorage(c echo.Context) error {
 	// Destroy the infrastructure
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}
 	// subcommand: destroy
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
 	if err != nil {
 		err2 := fmt.Errorf("failed, previous request in progress")
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -813,7 +814,7 @@ func GetRequestStatusOfObjectStorage(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -834,7 +835,7 @@ func GetRequestStatusOfObjectStorage(c echo.Context) error {
 	statusLogFile := fmt.Sprintf("%s/runningLogs/%s.log", workingDir, reqId)
 
 	// Check the statusReport of the request
-	statusReport, err := tfutil.GetRunningStatus(trId, statusLogFile)
+	statusReport, err := tofu.GetExcutionHistory(trId, statusLogFile)
 	if err != nil {
 		err2 := fmt.Errorf("failed to get the status of the request")
 		log.Error().Err(err).Msg(err2.Error()) // error

--- a/pkg/api/rest/handler/sql-db.go
+++ b/pkg/api/rest/handler/sql-db.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloud-barista/mc-terrarium/pkg/api/rest/model"
 	"github.com/cloud-barista/mc-terrarium/pkg/config"
 	"github.com/cloud-barista/mc-terrarium/pkg/terrarium"
+	"github.com/cloud-barista/mc-terrarium/pkg/tofu"
 	tfutil "github.com/cloud-barista/mc-terrarium/pkg/tofu/util"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -91,7 +92,7 @@ func InitEnvForSqlDb(c echo.Context) error {
 	enrichments := "sql-db"
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -100,7 +101,7 @@ func InitEnvForSqlDb(c echo.Context) error {
 	}
 
 	trInfo.Enrichments = enrichments
-	err = terrarium.UpdateTerrariumInfo(trInfo)
+	err = terrarium.UpdateInfo(trInfo)
 	if err != nil {
 		err2 := fmt.Errorf("failed to update terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -153,7 +154,7 @@ func InitEnvForSqlDb(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/vpn/gcp-aws
 	// init: subcommand
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "init")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "init")
 	if err != nil {
 		err2 := fmt.Errorf("failed to initialize an infrastructure terrarium")
 		log.Error().Err(err).Msg(err2.Error())
@@ -204,7 +205,7 @@ func ClearEnvOfSqlDb(c echo.Context) error {
 	projectRoot := config.Terrarium.Root
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -287,7 +288,7 @@ func CreateInfracodeForSqlDb(c echo.Context) error {
 	projectRoot := config.Terrarium.Root
 
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -320,7 +321,7 @@ func CreateInfracodeForSqlDb(c echo.Context) error {
 		req.TfVars.TerrariumID = trId
 	}
 
-	err = tfutil.SaveTfVarsToFile(req.TfVars, tfVarsPath)
+	err = tfutil.SaveTfVars(req.TfVars, tfVarsPath)
 	if err != nil {
 		err2 := fmt.Errorf("failed to save tfVars to a file")
 		log.Error().Err(err).Msg(err2.Error())
@@ -372,7 +373,7 @@ func CheckInfracodeForSqlDb(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -394,7 +395,7 @@ func CheckInfracodeForSqlDb(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/sql-db
 	// subcommand: plan
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "plan")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "plan")
 	if err != nil {
 		err2 := fmt.Errorf("returned: %s", ret)
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -447,7 +448,7 @@ func CreateSqlDb(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -469,7 +470,7 @@ func CreateSqlDb(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/vpn/gcp-aws
 	// subcommand: apply
-	_, err = tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "apply", "-auto-approve")
+	_, err = tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "apply", "-auto-approve")
 	if err != nil {
 		err2 := fmt.Errorf("failed, previous request in progress")
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -482,7 +483,7 @@ func CreateSqlDb(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/sql-db
 	// show: subcommand
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "sql_db_info")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "sql_db_info")
 	if err != nil {
 		err2 := fmt.Errorf("failed to read resource info (detail: %s) specified as 'output' in the state file", "refined")
 		log.Error().Err(err).Msg(err2.Error())
@@ -570,7 +571,7 @@ func GetResourceInfoOfSqlDb(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -597,7 +598,7 @@ func GetResourceInfoOfSqlDb(c echo.Context) error {
 
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/sql-db
 		// show: subcommand
-		ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "sql_db_info")
+		ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "output", "-json", "sql_db_info")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) specified as 'output' in the state file", DetailOptions.Refined)
 			log.Error().Err(err).Msg(err2.Error())
@@ -634,7 +635,7 @@ func GetResourceInfoOfSqlDb(c echo.Context) error {
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/vpn/gcp-aws
 		// show: subcommand
 		// Get resource info from the state or plan file
-		ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "show", "-json")
+		ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "show", "-json")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) from the state or plan file", DetailOptions.Raw)
 			log.Error().Err(err).Msg(err2.Error()) // error
@@ -719,7 +720,7 @@ func DestroySqlDb(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -742,7 +743,7 @@ func DestroySqlDb(c echo.Context) error {
 	// Destroy the infrastructure
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}
 	// subcommand: destroy
-	ret, err := tfutil.ExecuteTofuCommand(trId, reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
+	ret, err := tofu.ExecuteCommand(trId, reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
 	if err != nil {
 		err2 := fmt.Errorf("failed, previous request in progress")
 		log.Error().Err(err).Msg(err2.Error()) // error
@@ -802,7 +803,7 @@ func GetRequestStatusOfSqlDb(c echo.Context) error {
 
 	projectRoot := config.Terrarium.Root
 	// Read and set the enrichments to terrarium information
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		err2 := fmt.Errorf("failed to read terrarium information")
 		log.Error().Err(err).Msg(err2.Error())
@@ -823,7 +824,7 @@ func GetRequestStatusOfSqlDb(c echo.Context) error {
 	statusLogFile := fmt.Sprintf("%s/runningLogs/%s.log", workingDir, reqId)
 
 	// Check the statusReport of the request
-	statusReport, err := tfutil.GetRunningStatus(trId, statusLogFile)
+	statusReport, err := tofu.GetExcutionHistory(trId, statusLogFile)
 	if err != nil {
 		err2 := fmt.Errorf("failed to get the status of the request")
 		log.Error().Err(err).Msg(err2.Error()) // error

--- a/pkg/api/rest/handler/terrarium.go
+++ b/pkg/api/rest/handler/terrarium.go
@@ -60,14 +60,14 @@ func IssueTerrarium(c echo.Context) error {
 		}
 	}
 
-	err := terrarium.IssueTerrarium(*reqTrInfo)
+	err := terrarium.IssueID(*reqTrInfo)
 
 	if err != nil {
 		res := model.Response{Success: false, Message: err.Error()}
 		return c.JSON(http.StatusInternalServerError, res)
 	}
 
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		text := fmt.Sprintf("no terrarium with the given ID (trId: %s)", trId)
 		res := model.Response{Success: true, Message: text}
@@ -89,7 +89,7 @@ func IssueTerrarium(c echo.Context) error {
 // @Router /tr [get]
 func ReadAllTerrarium(c echo.Context) error {
 
-	trInfoList, _ := terrarium.ReadAllTerrariumInfo()
+	trInfoList, _ := terrarium.ReadAllInfo()
 
 	return c.JSON(http.StatusOK, trInfoList)
 }
@@ -113,7 +113,7 @@ func ReadTerrarium(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, res)
 	}
 
-	trInfo, err := terrarium.ReadTerrariumInfo(trId)
+	trInfo, err := terrarium.GetInfo(trId)
 	if err != nil {
 		text := fmt.Sprintf("no terrarium with the given ID (trId: %s)", trId)
 		res := model.Response{Success: true, Message: text}
@@ -158,7 +158,7 @@ func EraseTerrarium(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, res)
 	}
 
-	err = terrarium.DeleteTerrariumInfo(trId)
+	err = terrarium.DeleteInfo(trId)
 	if err != nil {
 		res := model.Response{Success: false, Message: err.Error()}
 		return c.JSON(http.StatusInternalServerError, res)

--- a/pkg/api/rest/handler/test-env.go
+++ b/pkg/api/rest/handler/test-env.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cloud-barista/mc-terrarium/pkg/api/rest/model"
 	"github.com/cloud-barista/mc-terrarium/pkg/config"
+	"github.com/cloud-barista/mc-terrarium/pkg/tofu"
 	tfutil "github.com/cloud-barista/mc-terrarium/pkg/tofu/util"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -85,7 +86,7 @@ func InitTerrariumForTestEnv(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/test-env
 	// init: subcommand
-	ret, err := tfutil.ExecuteTofuCommand("test-env", reqId, "-chdir="+workingDir, "init")
+	ret, err := tofu.ExecuteCommand("test-env", reqId, "-chdir="+workingDir, "init")
 	if err != nil {
 		res := model.Response{Success: false, Message: "Failed to init"}
 		return c.JSON(http.StatusInternalServerError, res)
@@ -197,7 +198,7 @@ func GetResouceInfoOfTestEnv(c echo.Context) error {
 
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/vpn/gcp-aws
 		// show: subcommand
-		ret, err := tfutil.ExecuteTofuCommand("test-env", reqId, "-chdir="+workingDir, "output", "-json")
+		ret, err := tofu.ExecuteCommand("test-env", reqId, "-chdir="+workingDir, "output", "-json")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) specified as 'output' in the state file", DetailOptions.Refined)
 			log.Error().Err(err).Msg(err2.Error())
@@ -234,7 +235,7 @@ func GetResouceInfoOfTestEnv(c echo.Context) error {
 		// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/{trId}/vpn/gcp-aws
 		// show: subcommand
 		// Get resource info from the state or plan file
-		ret, err := tfutil.ExecuteTofuCommand("test-env", reqId, "-chdir="+workingDir, "show", "-json")
+		ret, err := tofu.ExecuteCommand("test-env", reqId, "-chdir="+workingDir, "show", "-json")
 		if err != nil {
 			err2 := fmt.Errorf("failed to read resource info (detail: %s) from the state or plan file", DetailOptions.Raw)
 			log.Error().Err(err).Msg(err2.Error()) // error
@@ -324,7 +325,7 @@ func CreateInfracodeOfTestEnv(c echo.Context) error {
 	// - Files named exactly terraform.tfvars or terraform.tfvars.json.
 	// - Any files with names ending in .auto.tfvars or .auto.tfvars.json.
 
-	err := tfutil.SaveTfVarsToFile(req.TfVars, tfVarsPath)
+	err := tfutil.SaveTfVars(req.TfVars, tfVarsPath)
 	if err != nil {
 		res := model.Response{Success: false, Message: "Failed to save tfVars to a file"}
 		return c.JSON(http.StatusInternalServerError, res)
@@ -364,7 +365,7 @@ func CheckInfracodeOfTestEnv(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/test-env
 	// subcommand: plan
-	ret, err := tfutil.ExecuteTofuCommand("test-env", reqId, "-chdir="+workingDir, "plan")
+	ret, err := tofu.ExecuteCommand("test-env", reqId, "-chdir="+workingDir, "plan")
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to plan") // error
 		text := fmt.Sprintf("Failed to plan\n(ret: %s)", ret)
@@ -405,7 +406,7 @@ func CreateTestEnv(c echo.Context) error {
 
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/test-env
 	// subcommand: apply
-	ret, err := tfutil.ExecuteTofuCommandAsync("test-env", reqId, "-chdir="+workingDir, "apply", "-auto-approve")
+	ret, err := tofu.ExecuteCommandAsync("test-env", reqId, "-chdir="+workingDir, "apply", "-auto-approve")
 	if err != nil {
 		res := model.Response{Success: false, Message: "Failed to deploy test environment"}
 		return c.JSON(http.StatusInternalServerError, res)
@@ -445,7 +446,7 @@ func DestroyTestEnv(c echo.Context) error {
 	// Destroy the infrastructure
 	// global option to set working dir: -chdir=/home/ubuntu/dev/cloud-barista/mc-terrarium/.terrarium/test-env
 	// subcommand: destroy
-	ret, err := tfutil.ExecuteTofuCommandAsync("test-env", reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
+	ret, err := tofu.ExecuteCommandAsync("test-env", reqId, "-chdir="+workingDir, "destroy", "-auto-approve")
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to destroy") // error
 		text := fmt.Sprintf("Failed to destroy: %s", ret)
@@ -490,7 +491,7 @@ func GetRequestStatusOfTestEnv(c echo.Context) error {
 	statusLogFile := fmt.Sprintf("%s/runningLogs/%s.log", workingDir, reqId)
 
 	// Check the statusReport of the request
-	statusReport, err := tfutil.GetRunningStatus("test-env", statusLogFile)
+	statusReport, err := tofu.GetExcutionHistory("test-env", statusLogFile)
 	if err != nil {
 		res := model.Response{Success: false, Message: "Failed to get the status of the request"}
 		return c.JSON(http.StatusInternalServerError, res)

--- a/pkg/api/rest/handler/vpn-aws-to-site-actions.go
+++ b/pkg/api/rest/handler/vpn-aws-to-site-actions.go
@@ -1,0 +1,506 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/cloud-barista/mc-terrarium/pkg/api/rest/model"
+	"github.com/cloud-barista/mc-terrarium/pkg/terrarium"
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
+	"github.com/tidwall/gjson"
+)
+
+/*
+ * [API - AWS to Site VPN] OpenTofu Actions (for fine-grained contorl)
+ */
+
+// InitAwsToSiteVpn godoc
+// @Summary Init AWS to site VPN
+// @Description Init AWS to site VPN
+// @Tags [AWS to site VPN] OpenTofu Actions (for fine-grained contorl)
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param ReqBody body model.CreateAwsToSiteVpnRequest true "Parameters requied to create the AWS to site VPN"
+// @Param x-request-id header string false "Custom request ID"
+// @Success 201 {object} model.Response "Created"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site/actions/init [post]
+func InitAwsToSiteVpn(c echo.Context) error {
+
+	res, err := initAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		res := model.Response{Success: false, Message: err.Error()}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+func initAwsToSiteVpn(c echo.Context) (model.Response, error) {
+
+	emptyRes := model.Response{}
+
+	/*
+	 * [Input] Get and validate
+	 */
+	trId := c.Param("trId")
+	if trId == "" {
+		err := fmt.Errorf("invalid request, terrarium ID (trId: %s) is required", trId)
+		log.Warn().Msg(err.Error())
+		return emptyRes, err
+	}
+
+	req := new(model.CreateAwsToSiteVpnRequest)
+	if err := c.Bind(req); err != nil {
+		err2 := fmt.Errorf("invalid request format, %v", err)
+		log.Warn().Err(err).Msg("invalid request format")
+		return emptyRes, err2
+	}
+	log.Debug().Msgf("%#v", req) // debug
+
+	if req.VpnConfig.TerrariumId == "" {
+		req.VpnConfig.TerrariumId = trId
+	}
+
+	// Validate the request
+	if err := req.VpnConfig.Validate(); err != nil {
+		log.Warn().Err(err).Msg("invalid request data")
+		return emptyRes, err
+	}
+
+	/*
+	* [Process] Prepare and execute the init command
+	*/
+
+	// Get the request ID
+	reqId := c.Response().Header().Get(echo.HeaderXRequestID)
+
+	// Set the enrichments
+	enrichments := "vpn/aws-to-site"
+
+	err := terrarium.SetEnrichments(trId, enrichments)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Set the terrarium environment
+	err = terrarium.CreateTerrariumEnv(trId, enrichments)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Set credentials for the terrarium environment
+	err = terrarium.SetCredentials(trId, enrichments, "gcp")
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Set the tfvars
+	err = terrarium.SaveTfVars(trId, enrichments, req)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Execute the init command
+	ret, err := terrarium.Init(trId, reqId)
+	if err != nil {
+		err2 := fmt.Errorf("failed to initialize an infrastructure terrarium")
+		log.Error().Err(err).Msg(err2.Error())
+		return emptyRes, err
+	}
+
+	/*
+	* [Output] Return the result
+	*/
+
+	res := model.Response{
+		Success: true,
+		Message: "successfully initialized the infrastructure terrarium",
+		Detail:  ret,
+	}
+
+	log.Debug().Msgf("%+v", res) // debug
+
+	return res, nil
+}
+
+// PlanAwsToSiteVpn godoc
+// @Summary Plan AWS to site VPN
+// @Description Plan AWS to site VPN
+// @Tags [AWS to site VPN] OpenTofu Actions (for fine-grained contorl)
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.Response "OK"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site/actions/plan [post]
+func PlanAwsToSiteVpn(c echo.Context) error {
+	
+	ret, err := planAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		res := model.Response{Success: false, Message: err.Error()}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+		
+	return c.JSON(http.StatusOK, ret)
+}
+
+func planAwsToSiteVpn(c echo.Context) (model.Response, error) {
+
+	emptyRes := model.Response{}
+	
+	trId := c.Param("trId")
+	if trId == "" {
+		err := fmt.Errorf("invalid request, terrarium ID (trId: %s) is required", trId)
+		log.Warn().Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Get the request ID
+	reqId := c.Response().Header().Get(echo.HeaderXRequestID)
+
+	// Execute the plan command
+	ret, err := terrarium.Plan(trId, reqId)
+	if err != nil {
+		err2 := fmt.Errorf("failed to plan the infrastructure terrarium")
+		log.Error().Err(err).Msg(err2.Error())
+		return emptyRes, err
+	}
+
+	res := model.Response{
+		Success: true,
+		Message: "successfully planned the infrastructure terrarium",
+		Detail:  ret,
+	}
+
+	log.Debug().Msgf("%+v", res) // debug
+
+	return res, nil
+}
+
+// ApplyAwsToSiteVpn godoc
+// @Summary Apply AWS to site VPN
+// @Description Apply AWS to site VPN
+// @Tags [AWS to site VPN] OpenTofu Actions (for fine-grained contorl)
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 201 {object} model.Response "Created"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site/actions/apply [post]
+func ApplyAwsToSiteVpn(c echo.Context) error {
+	
+	res, err := applyAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		res := model.Response{Success: false, Message: err.Error()}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+func applyAwsToSiteVpn(c echo.Context) (model.Response, error) {
+
+	emptyRes := model.Response{}
+
+	trId := c.Param("trId")
+	if trId == "" {
+		err := fmt.Errorf("invalid request, terrarium ID (trId: %s) is required", trId)
+		log.Warn().Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Get the request ID
+	reqId := c.Response().Header().Get(echo.HeaderXRequestID)
+
+	// Execute the apply command
+	ret, err := terrarium.Apply(trId, reqId)
+	if err != nil {
+		err2 := fmt.Errorf("failed to apply the infrastructure terrarium")
+		log.Error().Err(err).Msg(err2.Error())
+		return emptyRes, err
+	}
+
+	res := model.Response{
+		Success: true,
+		Message: "successfully applied the infrastructure terrarium",
+		Detail:  ret,
+	}
+
+	log.Debug().Msgf("%+v", res) // debug
+
+	return res, nil
+}
+
+// DestroyAwsToSiteVpn godoc
+// @Summary Destroy AWS to site VPN
+// @Description Destroy AWS to site VPN
+// @Tags [AWS to site VPN] OpenTofu Actions (for fine-grained contorl)
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.Response "OK"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site/actions/destroy [delete]
+func DestroyAwsToSiteVpn(c echo.Context) error {
+
+	res, err := destroyAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		res := model.Response{Success: false, Message: err.Error()}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+func destroyAwsToSiteVpn(c echo.Context) (model.Response, error) {
+
+	emptyRes := model.Response{}
+	
+	trId := c.Param("trId")
+	if trId == "" {
+		err := fmt.Errorf("invalid request, terrarium ID (trId: %s) is required", trId)
+		log.Warn().Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Get the request ID
+	reqId := c.Response().Header().Get(echo.HeaderXRequestID)
+
+	// Detach the imported route table for preventing to destroy the imported resource
+	err := terrarium.DetachImportedResource(trId, reqId, "aws_route_table.imported_route_table")	
+	if err != nil {
+		err2 := fmt.Errorf("failed to remove the imported route table")
+		log.Error().Err(err).Msg(err2.Error())
+		return emptyRes, err
+	}
+
+	// Execute the destroy command
+	ret, err := terrarium.Destroy(trId, reqId)
+	if err != nil {
+		err2 := fmt.Errorf("failed to destroy the infrastructure terrarium")
+		log.Error().Err(err).Msg(err2.Error())
+		return emptyRes, err
+	}
+
+	res := model.Response{
+		Success: true,
+		Message: "successfully destroyed the infrastructure terrarium",
+		Detail:  ret,
+	}
+	
+	log.Debug().Msgf("%+v", res) // debug
+
+	return res, nil
+}
+
+// OutputAwsToSiteVpn godoc
+// @Summary Output AWS to site VPN
+// @Description Output AWS to site VPN
+// @Tags [AWS to site VPN] OpenTofu Actions (for fine-grained contorl)
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param detail query string false "Resource info by detail (refined, raw)" Enums(refined, raw) default(refined)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.Response "OK"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site/actions/output [get]
+func OutputAwsToSiteVpn(c echo.Context) error {
+
+	res, err := outputAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		res := model.Response{Success: false, Message: err.Error()}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+		
+	return c.JSON(http.StatusOK, res)
+}
+
+func outputAwsToSiteVpn(c echo.Context) (model.Response, error) {
+
+	
+	emptyRes := model.Response{}
+	
+	trId := c.Param("trId")
+	if trId == "" {
+		err := fmt.Errorf("invalid request, terrarium ID (trId: %s) is required", trId)
+		log.Warn().Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Use this struct like the enum
+	var DetailOptions = struct {
+		Refined string
+		Raw     string
+	}{
+		Refined: "refined",
+		Raw:     "raw",
+	}
+
+		// valid detail options
+	validDetailOptions := map[string]bool{
+		DetailOptions.Refined: true,
+		DetailOptions.Raw:     true,
+	}
+
+	detail := c.QueryParam("detail")
+	detail = strings.ToLower(detail)
+
+	if detail == "" || !validDetailOptions[detail] {
+		err := fmt.Errorf("invalid detail (%s), use the default (%s)", detail, DetailOptions.Refined)
+		log.Warn().Msg(err.Error())
+		detail = DetailOptions.Refined
+	}
+
+	// Get the request ID
+	reqId := c.Response().Header().Get(echo.HeaderXRequestID)
+
+	// Get the resource info by the detail option
+	switch detail {
+	case DetailOptions.Refined:
+		// Execute the output command
+		ret, err := terrarium.Output(trId, reqId, "vpn_info", "-json") 
+		if err != nil {
+			err2 := fmt.Errorf("failed to output the infrastructure terrarium")
+			return emptyRes, err2
+		}
+
+		var resourceInfo map[string]interface{}
+		err = json.Unmarshal([]byte(ret), &resourceInfo)
+		if err != nil {
+			log.Error().Err(err).Msg("") // error
+			return emptyRes, err
+		}
+
+		res := model.Response{
+			Success: true,
+			Message: "refined read resource info (map)",
+			Object:  resourceInfo,
+		}
+		log.Debug().Msgf("%+v", res) // debug
+
+		return res, nil
+
+	case DetailOptions.Raw:
+		
+		// Execute the show command
+		ret, err := terrarium.Show(trId, reqId, "-json")
+		if err != nil {
+			err2 := fmt.Errorf("failed to show the infrastructure terrarium")
+			log.Error().Err(err).Msg(err2.Error())
+			return emptyRes, err2
+		}
+
+		// Parse the resource info
+		resourcesString := gjson.Get(ret, "values.root_module.resources").String()
+		if resourcesString == "" {
+			err2 := fmt.Errorf("could not find resource info (trId: %s)", trId)
+			log.Warn().Msg(err2.Error())
+			return emptyRes, err2
+		}
+
+		var resourceInfoList []interface{}
+		err = json.Unmarshal([]byte(resourcesString), &resourceInfoList)
+		if err != nil {
+			err2 := fmt.Errorf("failed to unmarshal resource info")
+			log.Error().Err(err).Msg(err2.Error()) // error
+			return emptyRes, err2
+		}
+
+		res := model.Response{
+			Success: true,
+			Message: "raw resource info (list)",
+			List:    resourceInfoList,
+		}
+		log.Debug().Msgf("%+v", res) // debug
+
+		return res, nil
+
+	default:		
+		err := fmt.Errorf("invalid detail option (%s)", detail)
+		log.Warn().Err(err).Msg("") // warn
+		
+		return emptyRes, err
+	}
+}
+
+// EmptyOutAwsToSiteVpn godoc
+// @Summary EmptyOut AWS to site VPN
+// @Description EmptyOut AWS to site VPN
+// @Tags [AWS to site VPN] OpenTofu Actions (for fine-grained contorl)
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.Response "OK"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site/actions/emptyout [delete]
+func EmptyOutAwsToSiteVpn(c echo.Context) error {
+
+	res, err := emptyOutAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		res := model.Response{Success: false, Message: err.Error()}
+		return c.JSON(http.StatusInternalServerError, res)
+	}	
+
+	return c.JSON(http.StatusOK, res)
+}
+
+func emptyOutAwsToSiteVpn(c echo.Context) (model.Response, error) {
+
+	emptyRes := model.Response{}
+
+	trId := c.Param("trId")
+	if trId == "" {
+		err := fmt.Errorf("invalid request, terrarium ID (trId: %s) is required", trId)
+		log.Warn().Msg(err.Error())
+		return emptyRes, err
+	}
+
+	// Execute the emptyout command
+	err := terrarium.EmptyOutTerrariumEnv(trId)
+	if err != nil {
+		err2 := fmt.Errorf("failed to empty out the infrastructure terrarium")
+		log.Error().Err(err).Msg(err2.Error())
+		return emptyRes, err2
+	}
+
+	res := model.Response{
+		Success: true,
+		Message: "successfully emptied out the infrastructure terrarium",
+	}
+	
+	log.Debug().Msgf("%+v", res) // debug
+
+	return res, nil
+}

--- a/pkg/api/rest/handler/vpn-aws-to-site.go
+++ b/pkg/api/rest/handler/vpn-aws-to-site.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
+)
+
+/*
+/ [API - AWS to Site VPN] Resource Operations
+*/
+
+// CreateAwsToSiteVpn godoc
+// @Summary Create AWS to site VPN
+// @Description Create AWS to site VPN
+// @Tags [AWS to site VPN] Resource Operations
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param ReqBody body model.CreateAwsToSiteVpnRequest true "Parameters requied to create the AWS to site VPN"
+// @Param x-request-id header string false "Custom request ID"
+// @Success 201 {object} model.Response "Created"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site [post]
+func CreateAwsToSiteVpn(c echo.Context) error {
+
+	// Handler workflow by sequenctially running the following operation:
+	// 1. Initialize
+	// 2. Plan
+	// 3. Apply
+
+	res, err := initAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	res, err = planAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+	
+	res, err = applyAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+// GetAwsToSiteVpn godoc
+// @Summary Get AWS to site VPN
+// @Description Get AWS to site VPN
+// @Tags [AWS to site VPN] Resource Operations
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param detail query string false "Resource info by detail (refined, raw)" Enums(refined, raw) default(refined)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.Response "OK"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site [get]
+func GetAwsToSiteVpn(c echo.Context) error {
+	
+	// Handler workflow by sequenctially running the following operation:
+	// 1. Get
+
+	res, err := outputAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// DeleteAwsToSiteVpn godoc
+// @Summary Delete AWS to site VPN
+// @Description Delete AWS to site VPN
+// @Tags [AWS to site VPN] Resource Operations
+// @Accept json
+// @Produce json
+// @Param trId path string true "Terrarium ID" default(tr01)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.Response "OK"
+// @Failure 400 {object} model.Response "Bad Request"
+// @Failure 500 {object} model.Response "Internal Server Error"
+// @Failure 503 {object} model.Response "Service Unavailable"
+// @Router /tr/{trId}/vpn/aws-to-site [delete]
+func DeleteAwsToSiteVpn(c echo.Context) error {
+	
+	// Handler workflow by sequenctially running the following operation:
+	// 1. Destroy
+
+	res, err := destroyAwsToSiteVpn(c)
+	if err != nil {
+		log.Error().Err(err).Msg(err.Error())
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	// res, err = cleanAwsToSiteVpn(c)
+	// if err != nil {
+	// 	log.Error().Err(err).Msg(err.Error())
+	// 	return c.JSON(http.StatusInternalServerError, res)
+	// }
+
+	return c.JSON(http.StatusOK, res)
+}

--- a/pkg/api/rest/model/request.go
+++ b/pkg/api/rest/model/request.go
@@ -1,5 +1,10 @@
 package model
 
+// Request bodies for AWS to site VPN
+type CreateAwsToSiteVpnRequest struct {
+	VpnConfig AwsToSiteVpnConfig `json:"vpn_config"`
+}
+
 // Reqeust bodies for GCP-AWS VPN
 type CreateInfracodeOfGcpAwsVpnRequest struct {
 	TfVars TfVarsGcpAwsVpnTunnel `json:"tfVars"`
@@ -29,3 +34,4 @@ type CreateInfracodeOfObjectStorageRequest struct {
 type CreateInfracodeOfMessageBrokerRequest struct {
 	TfVars TfVarsMessageBroker `json:"tfVars"`
 }
+

--- a/pkg/api/rest/model/vpn-aws-to-site.go
+++ b/pkg/api/rest/model/vpn-aws-to-site.go
@@ -1,0 +1,455 @@
+package model
+
+import "fmt"
+
+/*
+ * Model for the AWS to site VPN configuration
+ */
+
+// GcpConfig represents GCP specific VPN configuration
+type GcpConfig struct {
+	Region         *string `json:"region,omitempty" default:"asia-northeast3" example:"asia-northeast3"`
+	VpcNetworkName string  `json:"vpc_network_name"`
+	BgpAsn         *string `json:"bgp_asn,omitempty" default:"65530" example:"65530"`
+}
+
+// AzureConfig represents Azure specific VPN configuration
+type AzureConfig struct {
+	Region              string  `json:"region"`
+	ResourceGroupName   string  `json:"resource_group_name"`
+	VirtualNetworkName  string  `json:"virtual_network_name"`
+	GatewaySubnetCidr   string  `json:"gateway_subnet_cidr"`
+	BgpAsn              *string `json:"bgp_asn,omitempty" default:"65531" example:"65531"`
+	VpnSku              *string `json:"vpn_sku,omitempty" default:"VpnGw1AZ" example:"VpnGw1AZ"`
+}
+
+// AlibabaConfig represents Alibaba Cloud specific VPN configuration
+type AlibabaConfig struct {
+	Region      *string `json:"region,omitempty" default:"ap-northeast-2" example:"ap-northeast-2"`
+	VpcId       string  `json:"vpc_id"`
+	VswitchId1  string  `json:"vswitch_id_1"`
+	VswitchId2  string  `json:"vswitch_id_2"`
+	BgpAsn      *string `json:"bgp_asn,omitempty" default:"65532" example:"65532"`
+}
+
+// IbmConfig represents IBM Cloud specific VPN configuration
+type IbmConfig struct {
+	Region    *string `json:"region,omitempty" default:"au-syd" example:"au-syd"`
+	VpcId     string  `json:"vpc_id"`
+	VpcCidr   string  `json:"vpc_cidr"`
+	SubnetId  string  `json:"subnet_id"`
+	BgpAsn    *string `json:"bgp_asn,omitempty" default:"65533" example:"65533"`
+}
+
+// // TencentConfig represents Tencent Cloud specific VPN configuration
+// // Currently commented out in the original definition
+// type TencentConfig struct {
+// 	Region  string `json:"region"`
+// 	VpcId   string `json:"vpc_id"`
+// 	BgpAsn  string `json:"bgp_asn"`
+// }
+
+// AwsConfig represents AWS specific VPN configuration
+type AwsConfig struct {
+	Region    *string `json:"region,omitempty" default:"ap-northeast-2" example:"ap-northeast-2"`
+	VpcId     string  `json:"vpc_id"`
+	SubnetId  string  `json:"subnet_id"`
+}
+
+// TargetCspConfig represents the target cloud service provider configuration
+type TargetCspConfig struct {
+	Type     string         `json:"type"`
+	Gcp      *GcpConfig     `json:"gcp,omitempty"`
+	Azure    *AzureConfig   `json:"azure,omitempty"`
+	Alibaba  *AlibabaConfig `json:"alibaba,omitempty"`
+	Ibm      *IbmConfig     `json:"ibm,omitempty"`
+	// Tencent  *TencentConfig `json:"tencent,omitempty"`
+}
+
+// AwsToSiteVpnConfig represents the main VPN configuration structure
+type AwsToSiteVpnConfig struct {
+	TerrariumId string         `json:"terrarium_id"`
+	Aws         AwsConfig      `json:"aws"`
+	TargetCsp   TargetCspConfig `json:"target_csp"`
+}
+
+// Validate validates the AWS to Site VPN configuration
+func (config *AwsToSiteVpnConfig) Validate() error {
+	// Validate TerrariumId
+	if config.TerrariumId == "" {
+		return fmt.Errorf("terrarium_id is required")
+	}
+
+	// Validate AWS configuration
+	if err := validateAwsConfig(config.Aws); err != nil {
+		return err
+	}
+
+	// Validate TargetCsp
+	if err := validateTargetCspConfig(config.TargetCsp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateAwsConfig validates AWS configuration
+func validateAwsConfig(aws AwsConfig) error {
+	// Check required AWS fields
+	if aws.VpcId == "" {
+		return fmt.Errorf("aws.vpc_id is required")
+	}
+	if aws.SubnetId == "" {
+		return fmt.Errorf("aws.subnet_id is required")
+	}
+
+	return nil
+}
+
+// validateTargetCspConfig validates target CSP configuration
+func validateTargetCspConfig(targetCsp TargetCspConfig) error {
+	// Validate CSP type
+	validTypes := map[string]bool{
+		"gcp":     true,
+		"azure":   true,
+		"alibaba": true,
+		"ibm":     true,
+		// "tencent": true,
+	}
+
+	if !validTypes[targetCsp.Type] {
+		return fmt.Errorf("invalid target_csp.type: %s. Must be one of: gcp, azure, alibaba, ibm, tencent", targetCsp.Type)
+	}
+
+	// Validate that the corresponding CSP configuration is provided
+	switch targetCsp.Type {
+	case "gcp":
+		if targetCsp.Gcp == nil {
+			return fmt.Errorf("gcp configuration is required when target_csp.type is 'gcp'")
+		}
+		if err := validateGcpConfig(*targetCsp.Gcp); err != nil {
+			return err
+		}
+	case "azure":
+		if targetCsp.Azure == nil {
+			return fmt.Errorf("azure configuration is required when target_csp.type is 'azure'")
+		}
+		if err := validateAzureConfig(*targetCsp.Azure); err != nil {
+			return err
+		}
+	case "alibaba":
+		if targetCsp.Alibaba == nil {
+			return fmt.Errorf("alibaba configuration is required when target_csp.type is 'alibaba'")
+		}
+		if err := validateAlibabaConfig(*targetCsp.Alibaba); err != nil {
+			return err
+		}
+	case "ibm":
+		if targetCsp.Ibm == nil {
+			return fmt.Errorf("ibm configuration is required when target_csp.type is 'ibm'")
+		}
+		if err := validateIbmConfig(*targetCsp.Ibm); err != nil {
+			return err
+		}
+	// case "tencent":
+	// 	if targetCsp.Tencent == nil {
+	// 		return fmt.Errorf("tencent configuration is required when target_csp.type is 'tencent'")
+	// 	}
+	// 	if err := validateTencentConfig(*targetCsp.Tencent); err != nil {
+	// 		return err
+	// 	}
+	}
+
+	return nil
+}
+
+// validateGcpConfig validates GCP configuration
+func validateGcpConfig(gcp GcpConfig) error {
+	if gcp.VpcNetworkName == "" {
+		return fmt.Errorf("gcp.vpc_network_name is required")
+	}
+	return nil
+}
+
+// validateAzureConfig validates Azure configuration
+func validateAzureConfig(azure AzureConfig) error {
+	if azure.Region == "" {
+		return fmt.Errorf("azure.region is required")
+	}
+	if azure.ResourceGroupName == "" {
+		return fmt.Errorf("azure.resource_group_name is required")
+	}
+	if azure.VirtualNetworkName == "" {
+		return fmt.Errorf("azure.virtual_network_name is required")
+	}
+	if azure.GatewaySubnetCidr == "" {
+		return fmt.Errorf("azure.gateway_subnet_cidr is required")
+	}
+	return nil
+}
+
+// validateAlibabaConfig validates Alibaba Cloud configuration
+func validateAlibabaConfig(alibaba AlibabaConfig) error {
+	if alibaba.VpcId == "" {
+		return fmt.Errorf("alibaba.vpc_id is required")
+	}
+	if alibaba.VswitchId1 == "" {
+		return fmt.Errorf("alibaba.vswitch_id_1 is required")
+	}
+	if alibaba.VswitchId2 == "" {
+		return fmt.Errorf("alibaba.vswitch_id_2 is required")
+	}
+	return nil
+}
+
+// validateIbmConfig validates IBM Cloud configuration
+func validateIbmConfig(ibm IbmConfig) error {
+	if ibm.VpcId == "" {
+		return fmt.Errorf("ibm.vpc_id is required")
+	}
+	if ibm.VpcCidr == "" {
+		return fmt.Errorf("ibm.vpc_cidr is required")
+	}
+	if ibm.SubnetId == "" {
+		return fmt.Errorf("ibm.subnet_id is required")
+	}
+	return nil
+}
+
+// // validateTencentConfig validates Tencent Cloud configuration
+// func validateTencentConfig(tencent TencentConfig) error {
+// 	if tencent.Region == "" {
+// 		return fmt.Errorf("tencent.region is required")
+// 	}
+// 	if tencent.VpcId == "" {
+// 		return fmt.Errorf("tencent.vpc_id is required")
+// 	}
+// 	if tencent.BgpAsn == "" {
+// 		return fmt.Errorf("tencent.bgp_asn is required")
+// 	}
+// 	return nil
+// }
+
+
+
+/*
+ * Model for the AWS to site VPN information
+ */
+
+// AwsVpnGateway represents AWS VPN gateway information
+type AwsVpnGateway struct {
+	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	VpcID        string `json:"vpc_id"`
+}
+
+// AwsCustomerGateway represents AWS customer gateway information
+type AwsCustomerGateway struct {
+	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	IPAddress    string `json:"ip_address"`
+	BgpAsn       string `json:"bgp_asn"`
+}
+
+// AwsVpnConnection represents AWS VPN connection information
+type AwsVpnConnection struct {
+	ResourceType   string `json:"resource_type"`
+	Name           string `json:"name"`
+	ID             string `json:"id"`
+	Tunnel1Address string `json:"tunnel1_address"`
+	Tunnel2Address string `json:"tunnel2_address"`
+}
+
+// AwsInfo represents AWS-specific VPN information
+type AwsInfo struct {
+	VpnGateway       AwsVpnGateway        `json:"vpn_gateway"`
+	CustomerGateways []AwsCustomerGateway `json:"customer_gateways"`
+	VpnConnections   []AwsVpnConnection   `json:"vpn_connections"`
+}
+
+// GcpVpnGateway represents GCP VPN gateway information
+type GcpVpnGateway struct {
+	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	Network      string `json:"network"`
+	Region       string `json:"region"`
+}
+
+// GcpExternalGatewayInterface represents interface for GCP external gateway
+type GcpExternalGatewayInterface struct {
+	ID        string `json:"id"`
+	IPAddress string `json:"ip_address"`
+}
+
+// GcpExternalGateway represents GCP external gateway information
+type GcpExternalGateway struct {
+	ResourceType   string                      `json:"resource_type"`
+	Name           string                      `json:"name"`
+	ID             string                      `json:"id"`
+	RedundancyType string                      `json:"redundancy_type"`
+	Description    string                      `json:"description"`
+	Interfaces     []GcpExternalGatewayInterface `json:"interfaces"`
+}
+
+// GcpRouter represents GCP router information
+type GcpRouter struct {
+	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	Network      string `json:"network"`
+	BgpAsn       string `json:"bgp_asn"`
+}
+
+// GcpTunnel represents GCP tunnel information
+type GcpTunnel struct {
+	Name      string `json:"name"`
+	ID        string `json:"id"`
+	PeerIP    string `json:"peer_ip"`
+	Interface int    `json:"interface"`
+}
+
+// GcpInterface represents GCP interface information
+type GcpInterface struct {
+	Name    string `json:"name"`
+	ID      string `json:"id"`
+	IPRange string `json:"ip_range"`
+}
+
+// GcpPeer represents GCP peer information
+type GcpPeer struct {
+	Name    string `json:"name"`
+	ID      string `json:"id"`
+	PeerIP  string `json:"peer_ip"`
+	PeerAsn string `json:"peer_asn"`
+}
+
+// GcpInfo represents GCP-specific target CSP information
+type GcpInfo struct {
+	VpnGateway      GcpVpnGateway     `json:"vpn_gateway"`
+	ExternalGateway GcpExternalGateway `json:"external_gateway"`
+	Router          GcpRouter         `json:"router"`
+	Tunnels         []GcpTunnel       `json:"tunnels"`
+	Interfaces      []GcpInterface    `json:"interfaces"`
+	Peers           []GcpPeer         `json:"peers"`
+}
+
+// AzureVpnGateway represents Azure VPN gateway information
+type AzureVpnGateway struct {
+	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	Location     string `json:"location"`
+	Sku          string `json:"sku"`
+}
+
+// AzurePublicIP represents Azure public IP information
+type AzurePublicIP struct {
+	Name      string `json:"name"`
+	ID        string `json:"id"`
+	IPAddress string `json:"ip_address"`
+}
+
+// AzureConnection represents Azure connection information
+type AzureConnection struct {
+	Name      string `json:"name"`
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	EnableBgp bool   `json:"enable_bgp"`
+}
+
+// AzureLocalGateway represents Azure local gateway information
+type AzureLocalGateway struct {
+	Name           string `json:"name"`
+	ID             string `json:"id"`
+	GatewayAddress string `json:"gateway_address"`
+}
+
+// AzureInfo represents Azure-specific target CSP information
+type AzureInfo struct {
+	VpnGateway    *AzureVpnGateway    `json:"vpn_gateway,omitempty"`
+	PublicIPs     []AzurePublicIP     `json:"public_ips"`
+	Connections   []AzureConnection   `json:"connections"`
+	LocalGateways []AzureLocalGateway `json:"local_gateways"`
+}
+
+// AlibabaVpnGateway represents Alibaba Cloud VPN gateway information
+type AlibabaVpnGateway struct {
+	ID                         string `json:"id"`
+	InternetIP                 string `json:"internet_ip"`
+	DisasterRecoveryInternetIP string `json:"disaster_recovery_internet_ip"`
+}
+
+// AlibabaCustomerGateway represents Alibaba Cloud customer gateway information
+type AlibabaCustomerGateway struct {
+	ID        string `json:"id"`
+	IPAddress string `json:"ip_address"`
+	Asn       string `json:"asn"`
+}
+
+// AlibabaTunnelOption represents Alibaba Cloud tunnel option information
+type AlibabaTunnelOption struct {
+	ID         string `json:"id"`
+	State      string `json:"state"`
+	Status     string `json:"status"`
+	BgpStatus  string `json:"bsp_status"`
+	PeerAsn    string `json:"peer_asn"`
+	PeerBgpIP  string `json:"peer_bgp_ip"`
+}
+
+// AlibabaVpnConnection represents Alibaba Cloud VPN connection information
+type AlibabaVpnConnection struct {
+	ID        string              `json:"id"`
+	BgpStatus string              `json:"bgp_status"`
+	Tunnels   []AlibabaTunnelOption `json:"tunnels"`
+}
+
+// AlibabaInfo represents Alibaba Cloud-specific target CSP information
+type AlibabaInfo struct {
+	VpnGateway      *AlibabaVpnGateway      `json:"vpn_gateway,omitempty"`
+	CustomerGateways []AlibabaCustomerGateway `json:"customer_gateways"`
+	VpnConnections  []AlibabaVpnConnection  `json:"vpn_connections"`
+}
+
+// IbmVpnGateway represents IBM Cloud VPN gateway information
+type IbmVpnGateway struct {
+	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+	ID           string `json:"id"`
+	PublicIP1    string `json:"public_ip_1"`
+	PublicIP2    string `json:"public_ip_2"`
+}
+
+// IbmVpnConnection represents IBM Cloud VPN connection information
+type IbmVpnConnection struct {
+	Name         string   `json:"name"`
+	ID           string   `json:"id"`
+	PresharedKey string   `json:"preshared_key"`
+	LocalCidrs   []string `json:"local_cidrs"`
+	PeerAddress  string   `json:"peer_address"`
+	PeerCidrs    []string `json:"peer_cidrs"`
+}
+
+// IbmInfo represents IBM Cloud-specific target CSP information
+type IbmInfo struct {
+	VpnGateway     *IbmVpnGateway     `json:"vpn_gateway,omitempty"`
+	VpnConnections []IbmVpnConnection `json:"vpn_connections"`
+}
+
+// TargetCspInfo represents target CSP information with all possible CSP types
+type TargetCspInfo struct {
+	Type    string      `json:"type"`
+	Gcp     *GcpInfo    `json:"gcp,omitempty"`
+	Azure   *AzureInfo  `json:"azure,omitempty"`
+	Alibaba *AlibabaInfo `json:"alibaba,omitempty"`
+	Ibm     *IbmInfo    `json:"ibm,omitempty"`
+}
+
+// VpnInfo represents the main VPN information output structure
+type VpnInfo struct {
+	Terrarium TerrariumInfo `json:"terrarium"`
+	Aws       AwsInfo       `json:"aws"`
+	TargetCsp TargetCspInfo `json:"target_csp"`
+}

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -205,15 +205,19 @@ func RunServer(port string) {
 	gTr.DELETE("/tr/:trId/vpn/gcp-azure", handler.DestroyGcpAzureVpn)
 	gTr.GET("/tr/:trId/vpn/gcp-azure/request/:requestId", handler.GetRequestStatusOfGcpAzureVpn)
 
-	// AWS-to-site VPN
-	// gTr.POST("/tr/:trId/vpn/aws-to-site/env", handler.InitEnvForAwsToSiteVpn)
-	// gTr.DELETE("/tr/:trId/vpn/aws-to-site/env", handler.ClearAwsToSiteVpn)
-	// gTr.GET("/tr/:trId/vpn/aws-to-site", handler.GetResourceInfoOfAwsToSiteVpn)
-	// gTr.POST("/tr/:trId/vpn/aws-to-site/infracode", handler.CreateInfracodeOfAwsToSiteVpn)
-	// gTr.POST("/tr/:trId/vpn/aws-to-site/plan", handler.CheckInfracodeOfAwsToSiteVpn)
-	// gTr.POST("/tr/:trId/vpn/aws-to-site", handler.CreateAwsToSiteVpn)
-	// gTr.DELETE("/tr/:trId/vpn/aws-to-site", handler.DestroyAwsToSiteVpn)
-	// gTr.GET("/tr/:trId/vpn/aws-to-site/request/:requestId", handler.GetRequestStatusOfAwsToSiteVpn)
+	// [AWS-to-site VPN] Resource operations (high-level APIs for resource-centric operations)
+	gTr.POST("/tr/:trId/vpn/aws-to-site", handler.CreateAwsToSiteVpn)
+	gTr.GET("/tr/:trId/vpn/aws-to-site", handler.GetAwsToSiteVpn)
+	// gTr.UPDATE("/tr/:trId/vpn/aws-to-site", handler.UpdateAwsToSiteVpn)
+	gTr.DELETE("/tr/:trId/vpn/aws-to-site", handler.DeleteAwsToSiteVpn)
+
+	// [AWS-to-site VPN] Tofu Actions (low-level APIs for advanced control)
+	gTr.POST("/tr/:trId/vpn/aws-to-site/actions/init", handler.InitAwsToSiteVpn)
+	gTr.POST("/tr/:trId/vpn/aws-to-site/actions/plan", handler.PlanAwsToSiteVpn)
+	gTr.POST("/tr/:trId/vpn/aws-to-site/actions/apply", handler.ApplyAwsToSiteVpn)
+	gTr.DELETE("/tr/:trId/vpn/aws-to-site/actions/destroy", handler.DestroyAwsToSiteVpn)
+	gTr.GET("/tr/:trId/vpn/aws-to-site/actions/output", handler.OutputAwsToSiteVpn)
+	gTr.DELETE("/tr/:trId/vpn/aws-to-site/actions/emptyout", handler.EmptyOutAwsToSiteVpn)
 
 	// SQL database APIs
 	gTr.POST("/tr/:trId/sql-db/env", handler.InitEnvForSqlDb)

--- a/pkg/lkvstore/lkvstore.go
+++ b/pkg/lkvstore/lkvstore.go
@@ -96,7 +96,7 @@ func LoadLkvStore() error {
 
 // Get returns the value for a given key.
 func Get(key string) (string, bool) {
-	log.Debug().Msgf("Get key: %s", key)
+
 	value, ok := lkvstore.Load(key)
 	if !ok {
 		log.Debug().Msgf("Get key: %s, value: %v", key, nil)
@@ -128,14 +128,13 @@ func GetWithPrefix(keyPrefix string) ([]string, bool) {
 
 // Put the key-value pair.
 func Put(key string, value interface{}) error {
-	log.Debug().Msgf("Put key: %s, value: %v", key, value)	
+
 	// Marshal the value to JSON
 	jsonValue, err := json.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("failed to marshal value: %w", err)
 	}
 
-	log.Debug().Msgf("Put key: %s, jsonValue: %s", key, string(jsonValue))
 	// Store the JSON string
 	lkvstore.Store(key, string(jsonValue))
 	return nil

--- a/pkg/tofu/tfclient/client.go
+++ b/pkg/tofu/tfclient/client.go
@@ -1,10 +1,10 @@
-package tfcli
+package tfclient
 
 import (
 	"errors"
 	"fmt"
 
-	tfutil "github.com/cloud-barista/mc-terrarium/pkg/tofu/util"
+	"github.com/cloud-barista/mc-terrarium/pkg/tofu"
 )
 
 // GlobalOptions defines global options for tofu commands.
@@ -123,10 +123,10 @@ func (c *Client) Exec() (string, error) {
 	}
 	
 	if c.async {
-		return tfutil.ExecuteTofuCommandAsync(c.trId, c.reqId, args...)
+		return tofu.ExecuteCommandAsync(c.trId, c.reqId, args...)
 	}
 	
-	return tfutil.ExecuteTofuCommand(c.trId, c.reqId, args...)
+	return tofu.ExecuteCommand(c.trId, c.reqId, args...)
 }
 
 // --- Main Commands ---
@@ -239,10 +239,104 @@ func (c *Client) Metadata() *Client {
 	return c
 }
 
-// State sets the state command.
-func (c *Client) State() *Client {
+// StateClient is a specialized client for state operations
+type StateClient struct {
+	*Client
+}
+
+// State sets the state command and returns a specialized StateClient.
+func (c *Client) State() *StateClient {
 	c.cmd = "state"
-	return c
+	return &StateClient{Client: c}
+}
+
+// List sets the "list" subcommand for state.
+func (s *StateClient) List() *StateClient {
+	s.args = append(s.args, "list")
+	return s
+}
+
+// Show sets the "show" subcommand for state.
+func (s *StateClient) Show(address string) *StateClient {
+	s.args = append(s.args, "show", address)
+	return s
+}
+
+// Move/Mv sets the "mv" subcommand for state to move resources.
+func (s *StateClient) Move(source, destination string) *StateClient {
+	s.args = append(s.args, "mv", source, destination)
+	return s
+}
+
+// Mv is an alias for Move.
+func (s *StateClient) Mv(source, destination string) *StateClient {
+	return s.Move(source, destination)
+}
+
+// Remove/Rm sets the "rm" subcommand for state to remove resources.
+func (s *StateClient) Remove(addresses ...string) *StateClient {
+	args := append([]string{"rm"}, addresses...)
+	s.args = append(s.args, args...)
+	return s
+}
+
+// Rm is an alias for Remove.
+func (s *StateClient) Rm(addresses ...string) *StateClient {
+	return s.Remove(addresses...)
+}
+
+// Pull sets the "pull" subcommand for state to pull remote state.
+func (s *StateClient) Pull() *StateClient {
+	s.args = append(s.args, "pull")
+	return s
+}
+
+// Push sets the "push" subcommand for state to push local state to remote.
+func (s *StateClient) Push() *StateClient {
+	s.args = append(s.args, "push")
+	return s
+}
+
+// Replace sets the "replace-provider" subcommand for state.
+func (s *StateClient) ReplaceProvider(fromProvider, toProvider string) *StateClient {
+	s.args = append(s.args, "replace-provider", fromProvider, toProvider)
+	return s
+}
+
+// WithFilter adds a filter to state operation (applicable to operations like list).
+func (s *StateClient) WithFilter(filter string) *StateClient {
+	s.args = append(s.args, filter)
+	return s
+}
+
+// WithStateOut specifies an output file for state operations (applicable to operations like pull).
+func (s *StateClient) WithStateOut(path string) *StateClient {
+	s.args = append(s.args, "-state-out="+path)
+	return s
+}
+
+// WithState specifies a state file to use for operations.
+func (s *StateClient) WithState(path string) *StateClient {
+	s.args = append(s.args, "-state="+path)
+	return s
+}
+
+// WithBackup specifies a backup path for state operations.
+func (s *StateClient) WithBackup(path string) *StateClient {
+	s.args = append(s.args, "-backup="+path)
+	return s
+}
+
+// WithBackupOut specifies an output path for the backup file.
+func (s *StateClient) WithBackupOut(path string) *StateClient {
+	s.args = append(s.args, "-backup-out="+path)
+	return s
+}
+
+// IgnoreRemoteVersion ignores remote version conflicts in state operations.
+func (s *StateClient) IgnoreRemoteVersion() *StateClient {
+	s.args = append(s.args, "-ignore-remote-version")
+	return s
 }
 
 // Taint sets the taint command.

--- a/pkg/tofu/tfclient/example/main.go
+++ b/pkg/tofu/tfclient/example/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cloud-barista/mc-terrarium/pkg/tofu/tfclient"
+)
+
+func main() {
+	// Define trace ID and request ID for tracking
+	traceID := "example-trace-001"
+	requestID := "example-req-001"
+	
+	fmt.Println("OpenTofu Client Examples")
+	fmt.Println("========================")
+	
+	// Example 1: Basic initialization
+	fmt.Println("\n=== Example 1: Initialize a Terraform project ===")
+	initExample(traceID, requestID)
+	
+	// Example 2: Plan with variables
+	fmt.Println("\n=== Example 2: Create a plan with variables ===")
+	planExample(traceID, requestID)
+	
+	// Example 3: Apply with auto-approve
+	fmt.Println("\n=== Example 3: Apply configuration with auto-approve ===")
+	applyExample(traceID, requestID)
+	
+	// Example 4: Show outputs in JSON format
+	fmt.Println("\n=== Example 4: Get outputs in JSON format ===")
+	outputExample(traceID, requestID)
+	
+	// Example 5: Destroy with variables
+	fmt.Println("\n=== Example 5: Destroy infrastructure ===")
+	destroyExample(traceID, requestID)
+	
+	// Example 6: Workspace management
+	fmt.Println("\n=== Example 6: Workspace management ===")
+	workspaceExample(traceID, requestID)
+	
+	// Example 7: Async command execution
+	fmt.Println("\n=== Example 7: Asynchronous command execution ===")
+	asyncExample(traceID, requestID)
+	
+	// Example 8: State management
+	fmt.Println("\n=== Example 8: State management ===")
+	stateExample(traceID, requestID)
+}
+
+// Basic initialization example
+func initExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// Initialize with backend reconfiguration and upgrade
+	result, err := client.Init().Reconfigure().Upgrade().Exec()
+	
+	if err != nil {
+		log.Printf("Error executing init: %v", err)
+		return
+	}
+	
+	fmt.Println("Init result:", result)
+}
+
+// Plan example with variables
+func planExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// Create plan with variables and output to a file
+	result, err := client.Plan().
+		SetVar("instance_count", "2").
+		SetVar("region", "us-west-2").
+		SetVarFile("env/prod.tfvars").
+		SetOut("tfplan").
+		NoColor().
+		Exec()
+	
+	if err != nil {
+		log.Printf("Error executing plan: %v", err)
+		return
+	}
+	
+	fmt.Println("Plan result:", result)
+}
+
+// Apply example with auto-approve
+func applyExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// Apply with auto-approve and parallelism settings
+	result, err := client.Apply().
+		Auto().
+		Parallelism(10).
+		SetVarFile("env/prod.tfvars").
+		Exec()
+	
+	if err != nil {
+		log.Printf("Error executing apply: %v", err)
+		return
+	}
+	
+	fmt.Println("Apply result:", result)
+}
+
+// Output example with JSON format
+func outputExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// Get specific output in JSON format
+	result, err := client.Output().
+		Json().
+		SetArg("instance_ips").
+		Exec()
+	
+	if err != nil {
+		log.Printf("Error getting outputs: %v", err)
+		return
+	}
+	
+	fmt.Println("Output result:", result)
+}
+
+// Destroy example
+func destroyExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// Destroy with auto-approve
+	result, err := client.Destroy().
+		Auto().
+		SetVarFile("env/prod.tfvars").
+		Exec()
+	
+	if err != nil {
+		log.Printf("Error executing destroy: %v", err)
+		return
+	}
+	
+	fmt.Println("Destroy result:", result)
+}
+
+// Workspace management example
+func workspaceExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// List workspaces
+	listResult, err := client.Workspace().SetArg("list").Exec()
+	if err != nil {
+		log.Printf("Error listing workspaces: %v", err)
+	} else {
+		fmt.Println("Workspace list:", listResult)
+	}
+	
+	// Create new workspace
+	newResult, err := client.Workspace().
+		SetArgs("new", "dev-environment").
+		Exec()
+	
+	if err != nil {
+		log.Printf("Error creating workspace: %v", err)
+	} else {
+		fmt.Println("New workspace result:", newResult)
+	}
+	
+	// Select workspace
+	selectResult, err := client.Workspace().
+		SetArgs("select", "dev-environment").
+		Exec()
+	
+	if err != nil {
+		log.Printf("Error selecting workspace: %v", err)
+	} else {
+		fmt.Println("Workspace select result:", selectResult)
+	}
+}
+
+// Async command execution example
+func asyncExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// Run plan asynchronously
+	jobID, err := client.Plan().
+		SetVarFile("env/prod.tfvars").
+		Async(true).
+		Exec()
+	
+	if err != nil {
+		log.Printf("Error starting async plan: %v", err)
+		return
+	}
+	
+	fmt.Println("Async job started with ID:", jobID)
+	fmt.Println("You can now poll for the results using this ID")
+}
+
+// State management example
+func stateExample(traceID, requestID string) {
+	client := tfclient.NewClient(traceID, requestID)
+	
+	// Set working directory
+	client.SetChdir("./terraform-project")
+	
+	// List all resources in state
+	fmt.Println("Listing all resources in state:")
+	listResult, err := client.State().List().Exec()
+	if err != nil {
+		log.Printf("Error listing state resources: %v", err)
+	} else {
+		fmt.Println(listResult)
+	}
+	
+	// Show details of a specific resource
+	fmt.Println("\nShowing details of a specific resource:")
+	showResult, err := client.State().Show("aws_instance.example").Exec()
+	if err != nil {
+		log.Printf("Error showing state resource: %v", err)
+	} else {
+		fmt.Println(showResult)
+	}
+	
+	// Move a resource in state
+	fmt.Println("\nMoving a resource in state:")
+	moveResult, err := client.State().Move(
+		"aws_instance.example", 
+		"aws_instance.web",
+	).Exec()
+	if err != nil {
+		log.Printf("Error moving state resource: %v", err)
+	} else {
+		fmt.Println(moveResult)
+	}
+	
+	// Remove a resource from state
+	fmt.Println("\nRemoving a resource from state:")
+	rmResult, err := client.State().Remove("aws_security_group.obsolete").Exec()
+	if err != nil {
+		log.Printf("Error removing state resource: %v", err)
+	} else {
+		fmt.Println(rmResult)
+	}
+	
+	// Pull remote state
+	fmt.Println("\nPulling remote state:")
+	pullResult, err := client.State().Pull().WithStateOut("./terraform.tfstate").Exec()
+	if err != nil {
+		log.Printf("Error pulling state: %v", err)
+	} else {
+		fmt.Println(pullResult)
+	}
+	
+	// List resources with filter
+	fmt.Println("\nListing resources with filter:")
+	filteredResult, err := client.State().List().WithFilter("aws_instance.*").Exec()
+	if err != nil {
+		log.Printf("Error listing filtered resources: %v", err)
+	} else {
+		fmt.Println(filteredResult)
+	}
+	
+	// Replace provider in state
+	fmt.Println("\nReplacing provider in state:")
+	replaceResult, err := client.State().ReplaceProvider(
+		"registry.terraform.io/hashicorp/aws",
+		"registry.terraform.io/hashicorp/aws-custom",
+	).Exec()
+	if err != nil {
+		log.Printf("Error replacing provider: %v", err)
+	} else {
+		fmt.Println(replaceResult)
+	}
+}

--- a/pkg/tofu/util/util.go
+++ b/pkg/tofu/util/util.go
@@ -24,8 +24,8 @@ func Version() (string, error) {
 }
 
 
-// SaveTfVarsToFile saves any tfVars structure to a JSON file
-func SaveTfVarsToFile(tfVars interface{}, file string) error {
+// SaveTfVars saves any tfVars structure to a JSON file
+func SaveTfVars(tfVars interface{}, file string) error {
 	// Convert tfVars to json
 	jsonData, err := json.MarshalIndent(tfVars, "", "  ")
 	if err != nil {

--- a/templates/vpn/aws-to-site/testbed/variables.tf
+++ b/templates/vpn/aws-to-site/testbed/variables.tf
@@ -2,6 +2,6 @@
 variable "environment" {
   description = "Environment name for tagging"
   type        = string
-  default     = "test"
+  default     = "testbed"
 }
 

--- a/templates/vpn/aws-to-site/vpn-aws-to-ibm.tf
+++ b/templates/vpn/aws-to-site/vpn-aws-to-ibm.tf
@@ -6,7 +6,6 @@ resource "aws_customer_gateway" "ibm_gw" {
   tags = {
     Name = "${local.name_prefix}-ibm-side-gw-${count.index + 1}"
   }
-  bgp_asn    = var.vpn_config.target_csp.ibm.bgp_asn
   ip_address = count.index % 2 == 0 ? ibm_is_vpn_gateway.vpn_gw[0].public_ip_address : ibm_is_vpn_gateway.vpn_gw[0].public_ip_address2
   type       = "ipsec.1"
 }


### PR DESCRIPTION
This PR will provide AWS-to-site VPN APIs. 

It makes us configure VPN between AWS and one of Azure, GCP, Alibaba, and IBM.

* Modularize AWS-to-site VPN core logic
* Provide APIs by combining core logics
* Classify APIs into the resource operation and OpenTofu Actions
  - APIs for resource operation provides CRUD operations for target resource
  - APIs for OpenTofu Actions provides fine-grained control like using OpenTofu CLI
* Define models for request and response bodies
* Update AWS-to-site VPN templates
* Update API docs
* Add Tofu client for usability, which supports method chaining
* Add Tofu client examples
* Enhance terrarium-driven functionalities
* Update related code blocks

![image](https://github.com/user-attachments/assets/268a2fe0-78cf-45c6-9375-a80b64a48c97)
