### PR TITLE
example(vpn): add AWS-DCS site-to-site connection

### DIFF
--- a/examples/dcs/vpn-to-aws/README.md
+++ b/examples/dcs/vpn-to-aws/README.md
@@ -1,0 +1,228 @@
+# AWS-DCS VPN Site-to-Site Connection
+
+This example demonstrates how to create a Site-to-Site VPN connection between AWS and DCS (Data Center Simulator) using OpenTofu/Terraform.
+
+## Architecture Overview
+
+```
+AWS VPC (10.0.0.0/16)                    DCS Network (192.168.0.0/24)
+├── Subnet (10.0.1.0/24)                 ├── Subnet (192.168.0.0/26)
+├── VPN Gateway                          ├── Router with external connectivity
+├── Customer Gateways (2)                ├── VPNaaS Service
+├── VPN Connection (2 tunnels)           ├── IKE Policy
+└── EC2 Instance (test)                  ├── IPSec Policy
+                                         ├── Site Connections (2)
+                                         └── Compute Instance (test)
+```
+
+## Prerequisites
+
+### AWS Requirements
+
+1. AWS CLI configured with appropriate credentials
+2. EC2 key pair created in the target region
+3. Appropriate IAM permissions for VPC, EC2, and VPN resources
+
+### DCS Requirements
+
+1. DCS environment running and accessible
+2. OpenStack CLI tools installed and configured
+3. Key pair created in DCS
+4. VPNaaS plugin enabled in DCS
+5. External network configured in DCS
+
+### Required Tools
+
+- [OpenTofu](https://opentofu.org/) >= 1.8.3
+- [AWS CLI](https://aws.amazon.com/cli/)
+- [OpenStack CLI](https://docs.openstack.org/python-openstackclient/latest/)
+
+## Configuration
+
+1. **Copy the example variables file:**
+
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   ```
+
+2. **Edit `terraform.tfvars` with your specific values:**
+
+   ```hcl
+   # AWS Configuration
+   aws_region     = "ap-northeast-2"
+   aws_vpc_cidr   = "10.0.0.0/16"
+   aws_key_pair_name = "your-aws-key-pair"
+
+   # DCS Configuration
+   openstack_user_name    = "your-username"
+   openstack_tenant_name  = "your-project"
+   openstack_password     = "your-password"
+   openstack_auth_url     = "http://your-dcs-ip:5000/v3"
+   openstack_key_pair_name = "your-openstack-key-pair"
+
+   # VPN Configuration
+   vpn_shared_secret = "your-secure-shared-secret"
+   ```
+
+3. **Set up AWS credentials:**
+
+   ```bash
+   aws configure
+   # OR
+   export AWS_ACCESS_KEY_ID="your-access-key"
+   export AWS_SECRET_ACCESS_KEY="your-secret-key"
+   ```
+
+4. **Set up OpenStack credentials (alternative to terraform.tfvars):**
+   ```bash
+   export OS_AUTH_URL="http://your-dcs-ip:5000/v3"
+   export OS_USERNAME="your-username"
+   export OS_PASSWORD="your-password"
+   export OS_PROJECT_NAME="your-project"
+   export OS_USER_DOMAIN_NAME="Default"
+   export OS_PROJECT_DOMAIN_NAME="Default"
+   ```
+
+## Deployment
+
+1. **Initialize OpenTofu:**
+
+   ```bash
+   tofu init
+   ```
+
+2. **Plan the deployment:**
+
+   ```bash
+   tofu plan
+   ```
+
+3. **Apply the configuration:**
+
+   ```bash
+   tofu apply
+   ```
+
+4. **View the outputs:**
+   ```bash
+   tofu output
+   ```
+
+## Verification
+
+### Check VPN Status
+
+**AWS VPN Connection:**
+
+```bash
+aws ec2 describe-vpn-connections --region ap-northeast-2
+```
+
+**OpenStack VPN Status:**
+
+```bash
+openstack vpn ipsec site connection list
+openstack vpn ipsec site connection show <connection-id>
+```
+
+### Test Connectivity
+
+1. **SSH to AWS instance:**
+
+   ```bash
+   ssh -i ~/.ssh/your-key.pem ubuntu@<aws-instance-public-ip>
+   ```
+
+2. **SSH to OpenStack instance:**
+
+   ```bash
+   ssh -i ~/.ssh/your-key.pem ubuntu@<openstack-floating-ip>
+   ```
+
+3. **Test cross-cloud connectivity:**
+
+   ```bash
+   # From AWS instance, ping OpenStack instance
+   ping <openstack-instance-private-ip>
+
+   # From OpenStack instance, ping AWS instance
+   ping <aws-instance-private-ip>
+   ```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **VPN Tunnel Down:**
+
+   - Check security groups allow VPN traffic
+   - Verify shared secrets match
+   - Check IKE/IPSec policy compatibility
+
+2. **BGP Issues:**
+
+   - Verify BGP ASN numbers are different
+   - Check APIPA address configuration
+   - Ensure proper routing table entries
+
+3. **OpenStack VPNaaS Issues:**
+   - Verify VPNaaS plugin is enabled: `openstack extension list | grep vpn`
+   - Check router has external gateway: `openstack router show <router-id>`
+   - Verify external network connectivity
+
+### Logs and Debugging
+
+**AWS VPN Logs:**
+
+- CloudWatch logs (if enabled)
+- VPC Flow Logs
+
+**OpenStack VPN Logs:**
+
+- Neutron VPNaaS agent logs: `/var/log/neutron/neutron-vpn-agent.log`
+- Check service status: `systemctl status neutron-vpn-agent`
+
+## Security Considerations
+
+1. **Shared Secret:** Use a strong, randomly generated shared secret
+2. **Security Groups:** Configure security groups to allow only necessary traffic
+3. **Key Management:** Secure your SSH keys and cloud credentials
+4. **Network Segmentation:** Use appropriate subnet CIDRs to avoid conflicts
+
+## Clean Up
+
+To destroy all created resources:
+
+```bash
+tofu destroy
+```
+
+## Cost Considerations
+
+### AWS Resources
+
+- VPN Gateway: ~$36/month (always running)
+- VPN Connection: ~$36/month per connection
+- EC2 instance: Variable based on instance type
+- Data transfer charges apply
+
+### DCS
+
+- DCS is typically free for development/testing
+- Production OpenStack deployments may have hosting costs
+
+## References
+
+- [AWS VPN Documentation](https://docs.aws.amazon.com/vpn/)
+- [OpenStack VPNaaS Documentation](https://docs.openstack.org/neutron-vpnaas/latest/)
+- [DCS VPNaaS Plugin](https://docs.openstack.org/neutron-vpnaas/latest/install/devstack.html)
+- [OpenTofu Documentation](https://opentofu.org/docs/)
+
+## Support
+
+For issues with this example:
+
+1. Check the troubleshooting section
+2. Review AWS and OpenStack logs
+3. Verify network connectivity and security groups
+4. Ensure all prerequisites are met

--- a/examples/dcs/vpn-to-aws/aws-networking.tf
+++ b/examples/dcs/vpn-to-aws/aws-networking.tf
@@ -1,0 +1,162 @@
+# AWS VPC and Networking Resources
+# Create VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.aws_vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
+}
+
+# Create Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name_prefix}-igw"
+  }
+}
+
+# Create subnet
+resource "aws_subnet" "main" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.aws_subnet_cidr
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.name_prefix}-subnet"
+  }
+}
+
+# Create route table
+resource "aws_route_table" "main" {
+  vpc_id = aws_vpc.main.id
+
+  # Route to Internet Gateway
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  # Route to DCS network via VPN
+  route {
+    cidr_block = var.openstack_network_cidr
+    gateway_id = aws_vpn_gateway.vgw.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-rt"
+  }
+}
+
+# Associate route table with subnet
+resource "aws_route_table_association" "main" {
+  subnet_id      = aws_subnet.main.id
+  route_table_id = aws_route_table.main.id
+}
+
+# Create VPN Gateway
+resource "aws_vpn_gateway" "vgw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name_prefix}-vpn-gateway"
+  }
+}
+
+# Create Customer Gateways for DCS VPN endpoints
+# Both gateways use the same DCS VPN service IP but connect to different tunnels
+resource "aws_customer_gateway" "cgw" {
+  bgp_asn    = var.openstack_bgp_asn
+  ip_address = openstack_vpnaas_service_v2.vpn.external_v4_ip
+  type       = "ipsec.1"
+
+  tags = {
+    Name = "${var.name_prefix}-cgw-tunnel-1"
+  }
+}
+
+# Create VPN Connections - Each uses the first tunnel only for true redundancy
+resource "aws_vpn_connection" "to_dcs" {
+  # vpn_gateway_id      = aws_vpn_gateway.main.id
+  # customer_gateway_id = aws_customer_gateway.cgw.id
+  # type                = "ipsec.1"
+  # static_routes_only  = true
+
+  # tags = {
+  #   Name = "${var.name_prefix}-vpn-connection-1"
+  # }
+
+  vpn_gateway_id      = aws_vpn_gateway.vgw.id
+  customer_gateway_id = aws_customer_gateway.cgw.id
+  type                = "ipsec.1"
+  static_routes_only  = true
+
+  tags = {
+    Name = "${var.name_prefix}-vpn-connection"
+  }
+
+  # Tunnel 1 configuration
+  tunnel1_ike_versions                 = ["ikev2"]
+  tunnel1_phase1_encryption_algorithms = ["AES256"]
+  tunnel1_phase1_integrity_algorithms  = ["SHA2-256"]
+  tunnel1_phase1_dh_group_numbers      = [14]
+  tunnel1_phase1_lifetime_seconds      = 28800
+
+  tunnel1_phase2_encryption_algorithms = ["AES256"]
+  tunnel1_phase2_integrity_algorithms  = ["SHA2-256"]
+  tunnel1_phase2_dh_group_numbers      = [14] # PFS
+  tunnel1_phase2_lifetime_seconds      = 3600
+
+  tunnel1_dpd_timeout_seconds = 30
+  tunnel1_dpd_timeout_action  = "restart"
+  # tunnel1_preshared_key       = local.psk1
+
+  # Tunnel 2 configuration
+  tunnel2_ike_versions                 = ["ikev2"]
+  tunnel2_phase1_encryption_algorithms = ["AES256"]
+  tunnel2_phase1_integrity_algorithms  = ["SHA2-256"]
+  tunnel2_phase1_dh_group_numbers      = [14]
+  tunnel2_phase1_lifetime_seconds      = 28800
+
+  tunnel2_phase2_encryption_algorithms = ["AES256"]
+  tunnel2_phase2_integrity_algorithms  = ["SHA2-256"]
+  tunnel2_phase2_dh_group_numbers      = [14]
+  tunnel2_phase2_lifetime_seconds      = 3600
+
+  tunnel2_dpd_timeout_seconds = 30
+  tunnel2_dpd_timeout_action  = "restart"
+  # tunnel2_preshared_key       = local.psk2
+}
+
+# Add static routes for DCS network (Required for static routing)
+resource "aws_vpn_connection_route" "route_to_dcs" {
+  vpn_connection_id      = aws_vpn_connection.to_dcs.id
+  destination_cidr_block = var.openstack_network_cidr
+}
+
+# Enable route propagation for VPN Gateway
+resource "aws_vpn_gateway_route_propagation" "prop" {
+  vpn_gateway_id = aws_vpn_gateway.vgw.id
+  route_table_id = aws_route_table.main.id
+}
+
+# Remove redundant aws_route resource as the route is already defined in aws_route_table.main
+# resource "aws_route" "to_dcs" {
+#   for_each               = toset(aws_route_table.main.*.id)
+#   route_table_id         = each.value
+#   destination_cidr_block = var.openstack_network_cidr
+#   gateway_id             = aws_vpn_gateway.vgw.id
+#   depends_on = [
+#     aws_vpn_connection.to_dcs,
+#     aws_vpn_connection_route.route_to_dcs
+#   ]
+# }
+
+# Data source for availability zones
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/examples/dcs/vpn-to-aws/instances.tf
+++ b/examples/dcs/vpn-to-aws/instances.tf
@@ -1,0 +1,108 @@
+# Test Instances for VPN Connectivity
+
+# Data sources for AMI and key pair
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# AWS EC2 Instance
+resource "aws_instance" "test" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "t3.micro"
+  subnet_id                   = aws_subnet.main.id
+  vpc_security_group_ids      = [aws_security_group.main.id]
+  associate_public_ip_address = true
+
+  # Use existing key pair or create one
+  key_name = aws_key_pair.main.key_name
+
+  user_data = base64encode(<<-EOF
+              #!/bin/bash
+              apt-get update
+              apt-get install -y nginx htop
+              echo "<h1>AWS Instance - ${var.name_prefix}</h1>" > /var/www/html/index.html
+              echo "<p>Private IP: $(hostname -I | awk '{print $1}')</p>" >> /var/www/html/index.html
+              systemctl start nginx
+              systemctl enable nginx
+              EOF
+  )
+
+  tags = {
+    Name = "${var.name_prefix}-aws-instance"
+  }
+}
+
+# Data sources for DCS
+data "openstack_images_image_v2" "ubuntu" {
+  name_regex  = "(?i)ubuntu.*22"
+  most_recent = true
+}
+
+data "openstack_compute_flavor_v2" "small" {
+  name = "m1.small"
+}
+
+# Create port for DCS instance (better OpenStack 2025.1 compatibility)
+resource "openstack_networking_port_v2" "test" {
+  name               = "${var.name_prefix}-port-test"
+  network_id         = openstack_networking_network_v2.main.id
+  admin_state_up     = true
+  security_group_ids = [openstack_networking_secgroup_v2.main.id]
+
+  fixed_ip {
+    subnet_id = openstack_networking_subnet_v2.main.id
+  }
+}
+
+# DCS Instance
+resource "openstack_compute_instance_v2" "test" {
+  name      = "${var.name_prefix}-openstack-instance"
+  image_id  = data.openstack_images_image_v2.ubuntu.id
+  flavor_id = data.openstack_compute_flavor_v2.small.id
+  key_pair  = openstack_compute_keypair_v2.main.name
+
+  # Use explicit port instead of network UUID and security groups
+  network {
+    port = openstack_networking_port_v2.test.id
+  }
+
+  user_data = base64encode(<<-EOF
+              #!/bin/bash
+              apt-get update
+              apt-get install -y nginx htop
+              echo "<h1>DCS Instance - ${var.name_prefix}</h1>" > /var/www/html/index.html
+              echo "<p>Private IP: $(hostname -I | awk '{print $1}')</p>" >> /var/www/html/index.html
+              systemctl start nginx
+              systemctl enable nginx
+              EOF
+  )
+
+  # Metadata
+  metadata = {
+    name_prefix = var.name_prefix
+    created_by  = "opentofu"
+  }
+}
+
+# Floating IP for DCS instance
+resource "openstack_networking_floatingip_v2" "test" {
+  pool        = data.openstack_networking_network_v2.external.name
+  description = "Floating IP for ${var.name_prefix}-openstack-instance"
+}
+
+# Associate floating IP with instance using explicit port
+resource "openstack_networking_floatingip_associate_v2" "test" {
+  floating_ip = openstack_networking_floatingip_v2.test.address
+  port_id     = openstack_networking_port_v2.test.id
+}

--- a/examples/dcs/vpn-to-aws/main.tf
+++ b/examples/dcs/vpn-to-aws/main.tf
@@ -1,0 +1,67 @@
+# VPN Site-to-Site Connection between AWS and DCS (Data Center Simulator)
+# This example demonstrates how to establish IPsec VPN tunnels between AWS and DCS
+
+# Define the required version of OpenTofu and the providers
+terraform {
+  # Required OpenTofu version
+  required_version = ">=1.8.3"
+
+  required_providers {
+    # AWS provider for AWS resources
+    aws = {
+      source  = "registry.opentofu.org/hashicorp/aws"
+      version = "~>5.42"
+    }
+
+    # OpenStack provider for DCS resources
+    openstack = {
+      source  = "registry.opentofu.org/terraform-provider-openstack/openstack"
+      version = "~>1.54"
+    }
+
+    # TLS provider for key generation
+    tls = {
+      source  = "registry.opentofu.org/hashicorp/tls"
+      version = "~>4.0"
+    }
+  }
+}
+
+# AWS Provider Configuration
+provider "aws" {
+  region = var.aws_region
+}
+
+# OpenStack Provider Configuration for DCS
+# Uses environment variables: OS_USERNAME, OS_PROJECT_NAME, OS_PASSWORD, OS_AUTH_URL, OS_REGION_NAME
+provider "openstack" {
+  # Configuration will be read from environment variables
+  # Make sure to source the credential file before running:
+  # source ../../secrets/load-openstack-cred-env.sh
+}
+
+# Generate SSH key pair for instances (shared between AWS and OpenStack)
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+# Create AWS Key Pair using the shared SSH key
+resource "aws_key_pair" "main" {
+  key_name   = "${var.name_prefix}-key"
+  public_key = tls_private_key.ssh.public_key_openssh
+
+  tags = {
+    Name = "${var.name_prefix}-key"
+  }
+}
+
+# Create OpenStack Key Pair using the same SSH key
+resource "openstack_compute_keypair_v2" "main" {
+  name       = "${var.name_prefix}-key"
+  public_key = tls_private_key.ssh.public_key_openssh
+}
+
+# Note: APIPA addresses are now auto-assigned by AWS
+# No need to manually specify tunnel inside CIDRs
+# All configuration is managed through variables

--- a/examples/dcs/vpn-to-aws/openstack-networking.tf
+++ b/examples/dcs/vpn-to-aws/openstack-networking.tf
@@ -1,0 +1,142 @@
+# DCS Networking Resources
+
+# Create network
+resource "openstack_networking_network_v2" "main" {
+  name           = "${var.name_prefix}-network"
+  admin_state_up = "true"
+}
+
+# Create subnet
+resource "openstack_networking_subnet_v2" "main" {
+  name            = "${var.name_prefix}-subnet"
+  network_id      = openstack_networking_network_v2.main.id
+  cidr            = var.openstack_subnet_cidr
+  ip_version      = 4
+  dns_nameservers = ["8.8.8.8", "8.8.4.4"]
+
+  allocation_pool {
+    start = cidrhost(var.openstack_subnet_cidr, 10)
+    end   = cidrhost(var.openstack_subnet_cidr, 50)
+  }
+}
+
+# Create router
+resource "openstack_networking_router_v2" "main" {
+  name                = "${var.name_prefix}-router"
+  admin_state_up      = true
+  external_network_id = data.openstack_networking_network_v2.external.id
+}
+
+# Attach subnet to router
+resource "openstack_networking_router_interface_v2" "main" {
+  router_id = openstack_networking_router_v2.main.id
+  subnet_id = openstack_networking_subnet_v2.main.id
+}
+
+# Create IKE Policy
+resource "openstack_vpnaas_ike_policy_v2" "ike" {
+  name                 = "${var.name_prefix}-ike-policy"
+  description          = "IKE policy for AWS VPN connection"
+  ike_version          = "v2"
+  encryption_algorithm = "aes-256"
+  auth_algorithm       = "sha256"
+  pfs                  = "group14"
+  # phase1_negotiation_mode = "main"
+
+  lifetime {
+    units = "seconds"
+    value = 28800
+  }
+}
+
+# Create IPSec Policy
+resource "openstack_vpnaas_ipsec_policy_v2" "ipsec" {
+  name                 = "${var.name_prefix}-ipsec-policy"
+  description          = "IPSec policy for AWS VPN connection"
+  transform_protocol   = "esp"
+  encapsulation_mode   = "tunnel"
+  encryption_algorithm = "aes-256"
+  auth_algorithm       = "sha256"
+  pfs                  = "group14"
+
+  lifetime {
+    units = "seconds"
+    value = 3600
+  }
+}
+
+# Create VPNaaS Service
+resource "openstack_vpnaas_service_v2" "vpn" {
+  name        = "${var.name_prefix}-vpn-service"
+  description = "VPN Service for AWS connection"
+  router_id   = openstack_networking_router_v2.main.id
+}
+
+# Create Endpoint Group for local subnets
+resource "openstack_vpnaas_endpoint_group_v2" "local" {
+  name        = "${var.name_prefix}-local-endpoints"
+  description = "Local endpoint group"
+  type        = "subnet"
+  endpoints   = [openstack_networking_subnet_v2.main.id]
+}
+
+# Create Endpoint Group for peer (AWS) subnets
+resource "openstack_vpnaas_endpoint_group_v2" "peer" {
+  name        = "${var.name_prefix}-peer-endpoints"
+  description = "Peer (AWS) endpoint group"
+  type        = "cidr"
+  endpoints   = [var.aws_vpc_cidr]
+}
+
+# Create Site Connection for Tunnel 1
+resource "openstack_vpnaas_site_connection_v2" "to_aws1" {
+  name           = "${var.name_prefix}-site-connection-1"
+  description    = "Site connection to AWS tunnel 1"
+  vpnservice_id  = openstack_vpnaas_service_v2.vpn.id
+  ikepolicy_id   = openstack_vpnaas_ike_policy_v2.ike.id
+  ipsecpolicy_id = openstack_vpnaas_ipsec_policy_v2.ipsec.id
+  psk            = aws_vpn_connection.to_dcs.tunnel1_preshared_key
+
+  peer_address = aws_vpn_connection.to_dcs.tunnel1_address
+  peer_id      = aws_vpn_connection.to_dcs.tunnel1_address
+  local_id     = openstack_vpnaas_service_v2.vpn.external_v4_ip
+
+  local_ep_group_id = openstack_vpnaas_endpoint_group_v2.local.id
+  peer_ep_group_id  = openstack_vpnaas_endpoint_group_v2.peer.id
+  mtu               = 1500
+
+  dpd {
+    action   = "restart"
+    timeout  = 30
+    interval = 10
+  }
+}
+
+# Create Site Connection for Tunnel 2
+resource "openstack_vpnaas_site_connection_v2" "to_aws2" {
+  name           = "${var.name_prefix}-site-connection-2"
+  description    = "Site connection to AWS tunnel 2"
+  vpnservice_id  = openstack_vpnaas_service_v2.vpn.id
+  ikepolicy_id   = openstack_vpnaas_ike_policy_v2.ike.id
+  ipsecpolicy_id = openstack_vpnaas_ipsec_policy_v2.ipsec.id
+  psk            = aws_vpn_connection.to_dcs.tunnel2_preshared_key
+
+  peer_address = aws_vpn_connection.to_dcs.tunnel2_address
+  peer_id      = aws_vpn_connection.to_dcs.tunnel2_address
+  local_id     = openstack_vpnaas_service_v2.vpn.external_v4_ip
+
+  local_ep_group_id = openstack_vpnaas_endpoint_group_v2.local.id
+  peer_ep_group_id  = openstack_vpnaas_endpoint_group_v2.peer.id
+  mtu               = 1500
+
+  dpd {
+    action   = "restart"
+    timeout  = 30
+    interval = 10
+  }
+}
+
+# Data source for external network (usually named 'public')
+data "openstack_networking_network_v2" "external" {
+  name = "public"
+}

--- a/examples/dcs/vpn-to-aws/outputs.tf
+++ b/examples/dcs/vpn-to-aws/outputs.tf
@@ -1,0 +1,173 @@
+# Output Values for VPN Connection Information
+
+# AWS Outputs
+output "aws_vpc_id" {
+  description = "AWS VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "aws_vpc_cidr" {
+  description = "AWS VPC CIDR block"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "aws_vpn_gateway_id" {
+  description = "AWS VPN Gateway ID"
+  value       = aws_vpn_gateway.vgw.id
+}
+
+output "aws_customer_gateway_ids" {
+  description = "AWS Customer Gateway IDs"
+  value = {
+    tunnel_1 = aws_customer_gateway.cgw.id
+    tunnel_2 = aws_customer_gateway.cgw.id
+  }
+}
+
+output "aws_vpn_connection_id" {
+  description = "AWS VPN Connection IDs"
+  value = {
+    connection_1 = aws_vpn_connection.to_dcs.id
+    connection_2 = aws_vpn_connection.to_dcs.id
+  }
+}
+
+output "aws_vpn_connection_tunnels" {
+  description = "AWS VPN Connection tunnel details"
+  value = {
+    connection_1_tunnel_1 = {
+      address            = aws_vpn_connection.to_dcs.tunnel1_address
+      bgp_asn            = aws_vpn_connection.to_dcs.tunnel1_bgp_asn
+      bgp_holdtime       = aws_vpn_connection.to_dcs.tunnel1_bgp_holdtime
+      inside_cidr        = aws_vpn_connection.to_dcs.tunnel1_inside_cidr
+      vgw_inside_address = aws_vpn_connection.to_dcs.tunnel1_vgw_inside_address
+      cgw_inside_address = aws_vpn_connection.to_dcs.tunnel1_cgw_inside_address
+      preshared_key      = aws_vpn_connection.to_dcs.tunnel1_preshared_key
+    }
+    connection_1_tunnel_2 = {
+      address            = aws_vpn_connection.to_dcs.tunnel2_address
+      bgp_asn            = aws_vpn_connection.to_dcs.tunnel2_bgp_asn
+      bgp_holdtime       = aws_vpn_connection.to_dcs.tunnel2_bgp_holdtime
+      inside_cidr        = aws_vpn_connection.to_dcs.tunnel2_inside_cidr
+      vgw_inside_address = aws_vpn_connection.to_dcs.tunnel2_vgw_inside_address
+      cgw_inside_address = aws_vpn_connection.to_dcs.tunnel2_cgw_inside_address
+      preshared_key      = aws_vpn_connection.to_dcs.tunnel2_preshared_key
+    }
+    connection_2_tunnel_1 = {
+      address            = aws_vpn_connection.to_dcs.tunnel1_address
+      bgp_asn            = aws_vpn_connection.to_dcs.tunnel1_bgp_asn
+      bgp_holdtime       = aws_vpn_connection.to_dcs.tunnel1_bgp_holdtime
+      inside_cidr        = aws_vpn_connection.to_dcs.tunnel1_inside_cidr
+      vgw_inside_address = aws_vpn_connection.to_dcs.tunnel1_vgw_inside_address
+      cgw_inside_address = aws_vpn_connection.to_dcs.tunnel1_cgw_inside_address
+      preshared_key      = aws_vpn_connection.to_dcs.tunnel1_preshared_key
+    }
+    connection_2_tunnel_2 = {
+      address            = aws_vpn_connection.to_dcs.tunnel2_address
+      bgp_asn            = aws_vpn_connection.to_dcs.tunnel2_bgp_asn
+      bgp_holdtime       = aws_vpn_connection.to_dcs.tunnel2_bgp_holdtime
+      inside_cidr        = aws_vpn_connection.to_dcs.tunnel2_inside_cidr
+      vgw_inside_address = aws_vpn_connection.to_dcs.tunnel2_vgw_inside_address
+      cgw_inside_address = aws_vpn_connection.to_dcs.tunnel2_cgw_inside_address
+      preshared_key      = aws_vpn_connection.to_dcs.tunnel2_preshared_key
+    }
+  }
+  sensitive = true
+}
+
+output "aws_instance_info" {
+  description = "AWS test instance information"
+  value = {
+    id         = aws_instance.test.id
+    private_ip = aws_instance.test.private_ip
+    public_ip  = aws_instance.test.public_ip
+  }
+}
+
+# DCS Outputs
+output "openstack_network_id" {
+  description = "DCS network ID"
+  value       = openstack_networking_network_v2.main.id
+}
+
+output "openstack_subnet_id" {
+  description = "DCS subnet ID"
+  value       = openstack_networking_subnet_v2.main.id
+}
+
+output "openstack_router_id" {
+  description = "DCS router ID"
+  value       = openstack_networking_router_v2.main.id
+}
+
+output "openstack_vpn_service_id" {
+  description = "DCS VPNaaS service ID"
+  value       = openstack_vpnaas_service_v2.vpn.id
+}
+
+output "openstack_vpn_service_external_ip" {
+  description = "DCS VPNaaS service external IP"
+  value       = openstack_vpnaas_service_v2.vpn.external_v4_ip
+}
+
+output "openstack_site_connections" {
+  description = "DCS VPN site connection details"
+  value = {
+    tunnel_1 = {
+      id = openstack_vpnaas_site_connection_v2.to_aws1.id
+    }
+    tunnel_2 = {
+      id = openstack_vpnaas_site_connection_v2.to_aws2.id
+    }
+  }
+}
+
+output "openstack_instance_info" {
+  description = "OpenStack test instance information"
+  value = {
+    id          = openstack_compute_instance_v2.test.id
+    name        = openstack_compute_instance_v2.test.name
+    private_ip  = openstack_compute_instance_v2.test.access_ip_v4
+    floating_ip = openstack_networking_floatingip_v2.test.address
+  }
+}
+
+# VPN Connection Summary
+output "vpn_connection_summary" {
+  description = "VPN connection summary"
+  value = {
+    aws_vpn_gateway_id       = aws_vpn_gateway.vgw.id
+    openstack_vpn_service_ip = openstack_vpnaas_service_v2.vpn.external_v4_ip
+    tunnel_count             = 2
+    shared_secret            = "*** HIDDEN ***"
+    aws_network              = var.aws_vpc_cidr
+    openstack_network        = var.openstack_network_cidr
+  }
+}
+
+# SSH Key Information (Shared between AWS and OpenStack)
+output "ssh_private_key_pem" {
+  description = "Private SSH key for accessing instances (use 'tofu output -raw ssh_private_key_pem > key.pem')"
+  value       = tls_private_key.ssh.private_key_pem
+  sensitive   = true
+}
+
+output "ssh_public_key" {
+  description = "Public SSH key (shared between AWS and OpenStack)"
+  value       = tls_private_key.ssh.public_key_openssh
+}
+
+output "key_pair_name" {
+  description = "Key pair name (same for both AWS and OpenStack)"
+  value       = "${var.name_prefix}-key"
+}
+
+output "aws_key_pair_name" {
+  description = "AWS key pair name"
+  value       = aws_key_pair.main.key_name
+}
+
+output "openstack_key_pair_name" {
+  description = "OpenStack key pair name"
+  value       = openstack_compute_keypair_v2.main.name
+}

--- a/examples/dcs/vpn-to-aws/security-groups.tf
+++ b/examples/dcs/vpn-to-aws/security-groups.tf
@@ -1,0 +1,101 @@
+# Security Groups for AWS and DCS
+
+# AWS Security Group
+resource "aws_security_group" "main" {
+  name        = "${var.name_prefix}-sg"
+  description = "Security group for VPN traffic"
+  vpc_id      = aws_vpc.main.id
+
+  # Allow inbound traffic from DCS network
+  ingress {
+    description = "All traffic from DCS network"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = [var.openstack_network_cidr]
+  }
+
+  ingress {
+    description = "ICMP from DCS network"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = [var.openstack_network_cidr]
+  }
+
+  # Allow ICMP from anywhere for ping testing
+  ingress {
+    description = "ICMP from anywhere"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow SSH access
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow all outbound traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-sg"
+  }
+}
+
+# DCS Security Group
+resource "openstack_networking_secgroup_v2" "main" {
+  name        = "${var.name_prefix}-sg"
+  description = "Security group for VPN traffic"
+}
+
+# Allow inbound traffic from AWS network
+resource "openstack_networking_secgroup_rule_v2" "aws_tcp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  remote_ip_prefix  = var.aws_vpc_cidr
+  security_group_id = openstack_networking_secgroup_v2.main.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "aws_icmp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = var.aws_vpc_cidr
+  security_group_id = openstack_networking_secgroup_v2.main.id
+}
+
+# Allow ICMP from anywhere for ping testing
+resource "openstack_networking_secgroup_rule_v2" "icmp_all" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.main.id
+}
+
+# Allow SSH access
+resource "openstack_networking_secgroup_rule_v2" "ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.main.id
+}
+
+# Note: Egress rules are typically created by default in OpenStack
+# No need to explicitly create egress_all rule to avoid conflicts

--- a/examples/dcs/vpn-to-aws/terraform.tfvars.example
+++ b/examples/dcs/vpn-to-aws/terraform.tfvars.example
@@ -1,0 +1,41 @@
+# Example values for AWS and DCS VPN connection
+# Copy this file to terraform.tfvars and modify the values according to your environment
+
+# DCS Connection Settings
+# Connection credentials are loaded from environment variables.
+# Before running OpenTofu, execute:
+# source ../../secrets/load-openstack-cred-env.sh
+#
+# Make sure to configure the following file with your DCS credentials:
+# ../../secrets/credential-openstack.env
+
+# AWS Configuration
+aws_region     = "ap-northeast-2"  # Seoul region
+aws_vpc_cidr   = "10.0.0.0/16"
+aws_subnet_cidr = "10.0.1.0/24"
+
+# DCS Network Configuration
+openstack_network_cidr = "192.168.0.0/24"
+openstack_subnet_cidr  = "192.168.0.0/26"
+
+# VPN Configuration
+vpn_shared_secret = "MyVPNSharedSecret123!"
+
+# Project Configuration
+project_name = "aws-dcs-vpn"
+environment  = "demo"
+
+# Key Pair Configuration (make sure these key pairs exist in both clouds)
+aws_key_pair_name       = "my-aws-key-pair"
+openstack_key_pair_name = "my-openstack-key-pair"
+
+# VPN Configuration
+vpn_shared_secret = "MyVPNSharedSecret123!"
+
+# Project Configuration
+project_name = "aws-dcs-vpn"
+environment  = "demo"
+
+# Key Pair Configuration (make sure these key pairs exist in both clouds)
+aws_key_pair_name       = "my-aws-key-pair"
+openstack_key_pair_name = "my-openstack-key-pair"

--- a/examples/dcs/vpn-to-aws/variables.tf
+++ b/examples/dcs/vpn-to-aws/variables.tf
@@ -1,0 +1,93 @@
+# 네이밍
+variable "name_prefix" {
+  type    = string
+  default = "tofu"
+}
+
+variable "add_random_suffix" {
+  type    = bool
+  default = true
+}
+
+# AWS
+# variable "aws_profile" {
+#   type    = string
+#   default = "default"
+# }
+
+variable "aws_region" {
+  type    = string
+  default = "ap-northeast-2"
+}
+
+variable "aws_vpc_id" {
+  type    = string
+  default = ""
+}
+
+variable "aws_vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "aws_subnet_cidr" {
+  type    = string
+  default = "10.0.1.0/24"
+}
+
+variable "aws_route_table_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "aws_bgp_asn" {
+  type    = number
+  default = 64512
+}
+
+# OpenStack
+variable "os_router_id" {
+  type    = string
+  default = ""
+}
+
+variable "os_local_cidr" {
+  type    = string
+  default = "192.168.0.0/24"
+}
+
+variable "os_public_ip" {
+  type    = string
+  default = ""
+}
+
+variable "os_subnet_id" {
+  type    = string
+  default = ""
+}
+
+variable "openstack_network_cidr" {
+  type    = string
+  default = "192.168.0.0/24"
+}
+
+variable "openstack_subnet_cidr" {
+  type    = string
+  default = "192.168.0.0/26"
+}
+
+# VPN Configuration
+variable "vpn_shared_secret" {
+  description = "Pre-shared key for VPN tunnels"
+  type        = string
+  default     = "MyVPNSharedSecret123!"
+  sensitive   = true
+}
+
+variable "openstack_bgp_asn" {
+  description = "BGP ASN for DCS (OpenStack) side"
+  type        = number
+  default     = 65000
+}
+
+


### PR DESCRIPTION
- Support VPN between AWS and DCS (OpenStack)
- Add VPNaaS service with dual tunnel config
- Implement IKE/IPSec policy compatibility
- Include test instances and security groups